### PR TITLE
[INTER-3888] Check isAddressSameAsShipping before calling it

### DIFF
--- a/view/frontend/web/js/model/address.js
+++ b/view/frontend/web/js/model/address.js
@@ -46,7 +46,7 @@ define([
             }
             const billing = registry.get('index = billingAddress');
             if (!street1) {
-                const street1Field = billing && billing.isAddressSameAsShipping()
+                const street1Field = billing && billing.hasOwnProperty('isAddressSameAsShipping') && billing.isAddressSameAsShipping()
                     ? registry.get('dataScope = shippingAddress.street.0')
                     : registry.get('dataScope = billingAddress.street.0');
                 if (street1Field) {
@@ -54,7 +54,7 @@ define([
                 }
             }
             if (!street2) {
-                const street2Field = billing && billing.isAddressSameAsShipping()
+                const street2Field = billing && billing.hasOwnProperty('isAddressSameAsShipping') && billing.isAddressSameAsShipping()
                     ? registry.get('dataScope = shippingAddress.street.1')
                     : registry.get('dataScope = billingAddress.street.1');
                 if (street2Field) {


### PR DESCRIPTION
Other Checkout Modules, like `Aheadworks_OneStepCheckout`, can have a billing address object without the function `isAddressSameAsShipping`. When the function is called the checkout will break and the customer can be stuck with a loading spinner indefinitely. 