### PR TITLE
[INTER-4401] Fixed property access on undefined when payment booster is disabled

### DIFF
--- a/view/frontend/web/js/view/payment/fastlane-methods.js
+++ b/view/frontend/web/js/view/payment/fastlane-methods.js
@@ -7,7 +7,7 @@ define([
 ) {
     'use strict';
 
-    if (window.checkoutConfig.bold.fastlane !== undefined) {
+    if (window.checkoutConfig?.bold?.fastlane !== undefined) {
         rendererList.push(
             {
                 type: 'bold_fastlane',


### PR DESCRIPTION
* Fixed console log that would happen when payment booster was installed but not enabled