### PR TITLE
[INTER-4629] [INTER-4630] Create Express Pay API Endpoints

### DIFF
--- a/Service/ExpressPay/Order/Create.php
+++ b/Service/ExpressPay/Order/Create.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\CheckoutPaymentBooster\Service\ExpressPay\Order;
+
+use Bold\Checkout\Api\Http\ClientInterface;
+use Bold\CheckoutPaymentBooster\Service\ExpressPay\QuoteConverter;
+use Exception;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Model\MaskedQuoteIdToQuoteIdInterface;
+use Magento\Quote\Model\Quote;
+
+use function __;
+use function count;
+use function implode;
+use function is_numeric;
+use function strlen;
+
+/**
+ * @api
+ */
+class Create
+{
+    /**
+     * @var MaskedQuoteIdToQuoteIdInterface
+     */
+    private $maskedQuoteIdToQuoteId;
+    /**
+     * @var CartRepositoryInterface
+     */
+    private $cartRepository;
+    /**
+     * @var QuoteConverter
+     */
+    private $quoteConverter;
+    /**
+     * @var ClientInterface
+     */
+    private $httpClient;
+
+    public function __construct(
+        MaskedQuoteIdToQuoteIdInterface $maskedQuoteIdToQuoteId,
+        CartRepositoryInterface $cartRepository,
+        QuoteConverter $quoteConverter,
+        ClientInterface $httpClient
+    ) {
+        $this->maskedQuoteIdToQuoteId = $maskedQuoteIdToQuoteId;
+        $this->cartRepository = $cartRepository;
+        $this->quoteConverter = $quoteConverter;
+        $this->httpClient = $httpClient;
+    }
+
+    /**
+     * @param string|int $quoteMaskId
+     * @param string $gatewayId
+     * @return void
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function execute($quoteMaskId, $gatewayId): void
+    {
+        if (!is_numeric($quoteMaskId) && strlen($quoteMaskId) === 32) {
+            try {
+                $quoteId = $this->maskedQuoteIdToQuoteId->execute($quoteMaskId);
+            } catch (NoSuchEntityException $noSuchEntityException) {
+                throw new LocalizedException(
+                    __('Could not create Express Pay order. Invalid quote mask ID "%1".', $quoteMaskId)
+                );
+            }
+        } else {
+            $quoteId = $quoteMaskId;
+        }
+
+        try {
+            /** @var Quote $quote */
+            $quote = $this->cartRepository->get((int)$quoteId);
+        } catch (NoSuchEntityException $noSuchEntityException) {
+            throw new LocalizedException(__('Could not create Express Pay order. Invalid quote ID "%1".', $quoteId));
+        }
+
+        $websiteId = (int)$quote->getStore()->getWebsiteId();
+        $uri = '/checkout/orders/{{shopId}}/wallet_pay';
+        $expressPayData = $this->quoteConverter->convertFullQuote($quote, $gatewayId);
+
+        try {
+            $result = $this->httpClient->post($websiteId, $uri, $expressPayData);
+        } catch (Exception $exception) {
+            throw new LocalizedException(
+                __('Could not create Express Pay order. Error: "%1"', $exception->getMessage())
+            );
+        }
+
+        $errors = $result->getErrors();
+
+        if (count($errors) > 0) {
+            throw new LocalizedException(
+                __('Could not create Express Pay order. Errors: "%1"', implode(', ', $errors))
+            );
+        }
+
+        if ($result->getStatus() !== 201) {
+            throw new LocalizedException(__('An unknown error occurred while creating the Express Pay order.'));
+        }
+    }
+}

--- a/Service/ExpressPay/Order/Create.php
+++ b/Service/ExpressPay/Order/Create.php
@@ -100,7 +100,7 @@ class Create
             );
         }
 
-        if ($result->getStatus() !== 201) {
+        if ($result->getStatus() !== 200) {
             throw new LocalizedException(__('An unknown error occurred while creating the Express Pay order.'));
         }
     }

--- a/Service/ExpressPay/Order/Create.php
+++ b/Service/ExpressPay/Order/Create.php
@@ -56,7 +56,8 @@ class Create
     /**
      * @param string|int $quoteMaskId
      * @param string $gatewayId
-     * @return array{paypal_order_id: string}
+     * @return array
+     * @phpstan-return array{paypal_order_id: string}
      * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function execute($quoteMaskId, $gatewayId): array

--- a/Service/ExpressPay/Order/Create.php
+++ b/Service/ExpressPay/Order/Create.php
@@ -56,10 +56,10 @@ class Create
     /**
      * @param string|int $quoteMaskId
      * @param string $gatewayId
-     * @return void
+     * @return array{paypal_order_id: string}
      * @throws \Magento\Framework\Exception\LocalizedException
      */
-    public function execute($quoteMaskId, $gatewayId): void
+    public function execute($quoteMaskId, $gatewayId): array
     {
         if (!is_numeric($quoteMaskId) && strlen($quoteMaskId) === 32) {
             try {
@@ -100,8 +100,21 @@ class Create
             );
         }
 
-        if ($result->getStatus() !== 200) {
+        /**
+         * @var array{
+         *     data: array{
+         *         order_id: string
+         *     }
+         * } $resultData
+         */
+        $resultData = $result->getBody();
+
+        if ($result->getStatus() !== 200 || count($resultData) === 0) {
             throw new LocalizedException(__('An unknown error occurred while creating the Express Pay order.'));
         }
+
+        return [
+            'paypal_order_id' => $resultData['data']['order_id']
+        ];
     }
 }

--- a/Service/ExpressPay/Order/Get.php
+++ b/Service/ExpressPay/Order/Get.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\CheckoutPaymentBooster\Service\ExpressPay\Order;
+
+use Bold\Checkout\Api\Http\ClientInterface;
+use Exception;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Store\Model\StoreManagerInterface;
+
+use function __;
+use function implode;
+
+/**
+ * @api
+ */
+class Get
+{
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+    /**
+     * @var ClientInterface
+     */
+    private $httpClient;
+
+    public function __construct(StoreManagerInterface $storeManager, ClientInterface $httpClient)
+    {
+        $this->storeManager = $storeManager;
+        $this->httpClient = $httpClient;
+    }
+
+    /**
+     * @param string $paypalOrderId
+     * @param string $gatewayId
+     * @return array
+     * @phpstan-return array{
+     *     first_name: string,
+     *     last_name: string,
+     *     email: string,
+     *     shipping_address: array{
+     *         address_line_1: string,
+     *         address_line_2: string,
+     *         city: string,
+     *         country: string,
+     *         province: string,
+     *         postal_code: string,
+     *         phone: string
+     *     },
+     *     billing_address: array{
+     *         address_line_1: string,
+     *         address_line_2: string,
+     *         city: string,
+     *         country: string,
+     *         province: string,
+     *         postal_code: string,
+     *         phone: string
+     *     }
+     * }
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function execute($paypalOrderId, $gatewayId): array
+    {
+        $websiteId = (int)$this->storeManager->getStore()->getWebsiteId();
+        $uri = "/checkout/orders/{{shopId}}/wallet_pay/$paypalOrderId?gateway_id=$gatewayId";
+
+        try {
+            $result = $this->httpClient->get($websiteId, $uri);
+        } catch (Exception $exception) {
+            throw new LocalizedException(
+                __('Could not get Express Pay order. Error: "%1"', $exception->getMessage())
+            );
+        }
+
+        $errors = $result->getErrors();
+
+        if (count($errors) > 0) {
+            throw new LocalizedException(
+                __('Could not get Express Pay order. Errors: "%1"', implode(', ', $errors))
+            );
+        }
+
+        if ($result->getStatus() !== 200) {
+            throw new LocalizedException(
+                __('An unknown error occurred while getting the Express Pay order.')
+            );
+        }
+
+        return $result->getBody(); // @phpstan-ignore return.type
+    }
+}

--- a/Service/ExpressPay/Order/Update.php
+++ b/Service/ExpressPay/Order/Update.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\CheckoutPaymentBooster\Service\ExpressPay\Order;
+
+use Bold\Checkout\Api\Http\ClientInterface;
+use Bold\CheckoutPaymentBooster\Service\ExpressPay\QuoteConverter;
+use Exception;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Model\MaskedQuoteIdToQuoteIdInterface;
+use Magento\Quote\Model\Quote;
+
+use function __;
+use function array_merge_recursive;
+use function count;
+use function implode;
+use function is_numeric;
+use function strlen;
+
+/**
+ * @api
+ */
+class Update
+{
+    /**
+     * @var MaskedQuoteIdToQuoteIdInterface
+     */
+    private $maskedQuoteIdToQuoteId;
+    /**
+     * @var CartRepositoryInterface
+     */
+    private $cartRepository;
+    /**
+     * @var QuoteConverter
+     */
+    private $quoteConverter;
+    /**
+     * @var ClientInterface
+     */
+    private $httpClient;
+
+    public function __construct(
+        MaskedQuoteIdToQuoteIdInterface $maskedQuoteIdToQuoteId,
+        CartRepositoryInterface $cartRepository,
+        QuoteConverter $quoteConverter,
+        ClientInterface $httpClient
+    ) {
+        $this->maskedQuoteIdToQuoteId = $maskedQuoteIdToQuoteId;
+        $this->cartRepository = $cartRepository;
+        $this->quoteConverter = $quoteConverter;
+        $this->httpClient = $httpClient;
+    }
+
+    /**
+     * @param string|int $quoteMaskId
+     * @param string $paypalOrderId
+     * @return void
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function execute($quoteMaskId, $paypalOrderId): void
+    {
+        if (!is_numeric($quoteMaskId) && strlen($quoteMaskId) === 32) {
+            try {
+                $quoteId = $this->maskedQuoteIdToQuoteId->execute($quoteMaskId);
+            } catch (NoSuchEntityException $noSuchEntityException) {
+                throw new LocalizedException(
+                    __('Could not update Express Pay order. Invalid quote mask ID "%1".', $quoteMaskId)
+                );
+            }
+        } else {
+            $quoteId = $quoteMaskId;
+        }
+
+        try {
+            /** @var Quote $quote */
+            $quote = $this->cartRepository->get((int)$quoteId);
+        } catch (NoSuchEntityException $noSuchEntityException) {
+            throw new LocalizedException(__('Could not update Express Pay order. Invalid quote ID "%1".', $quoteId));
+        }
+
+        $websiteId = (int)$quote->getStore()->getWebsiteId();
+        $uri = "/checkout/orders/{{shopId}}/wallet_pay/$paypalOrderId";
+        $expressPayData = array_merge_recursive(
+            $this->quoteConverter->convertShippingInformation($quote),
+            $this->quoteConverter->convertQuoteItems($quote),
+            $this->quoteConverter->convertTotal($quote),
+            $this->quoteConverter->convertTaxes($quote),
+            $this->quoteConverter->convertDiscount($quote)
+        );
+
+        try {
+            $result = $this->httpClient->patch($websiteId, $uri, $expressPayData);
+        } catch (Exception $exception) {
+            throw new LocalizedException(
+                __('Could not update Express Pay order. Error: "%1"', $exception->getMessage())
+            );
+        }
+
+        $errors = $result->getErrors();
+
+        if (count($errors) > 0) {
+            throw new LocalizedException(
+                __('Could not update Express Pay order. Errors: "%1"', implode(', ', $errors))
+            );
+        }
+
+        if ($result->getStatus() !== 204) {
+            throw new LocalizedException(__('An unknown error occurred while updating the Express Pay order.'));
+        }
+    }
+}

--- a/Service/ExpressPay/QuoteConverter.php
+++ b/Service/ExpressPay/QuoteConverter.php
@@ -197,7 +197,21 @@ class QuoteConverter
                         ];
                     },
                     $quote->getItems()
-                )
+                ),
+                'item_total' => [
+                    'currency_code' => $currencyCode ?? '',
+                    'value' => number_format(
+                        array_sum(
+                            array_map(
+                                static function (CartItemInterface $cartItem) {
+                                    return $cartItem->getPrice() * $cartItem->getQty();
+                                },
+                                $quote->getItems()
+                            )
+                        ),
+                        2
+                    )
+                ]
             ]
         ];
     }

--- a/Service/ExpressPay/QuoteConverter.php
+++ b/Service/ExpressPay/QuoteConverter.php
@@ -252,7 +252,7 @@ class QuoteConverter
             );
         } else {
             $convertedQuote['order_data']['tax_total']['value'] = number_format(
-                (float)$quote->getShippingAddress()->getTaxAmount(),
+                (float)($quote->getShippingAddress()->getTaxAmount() ?? 0.00),
                 2
             );
         }

--- a/Service/ExpressPay/QuoteConverter.php
+++ b/Service/ExpressPay/QuoteConverter.php
@@ -1,0 +1,271 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\CheckoutPaymentBooster\Service\ExpressPay;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Quote\Api\Data\CartItemInterface;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\Quote\Address\Rate;
+use Magento\Quote\Model\Quote\Item;
+use Magento\Store\Model\ScopeInterface;
+
+use function array_map;
+use function array_merge_recursive;
+use function array_sum;
+use function ceil;
+use function in_array;
+use function number_format;
+use function str_replace;
+use function trim;
+
+/**
+ * Translates Magento Quote data into Bold Checkout Express Pay Order data
+ *
+ * @api
+ */
+class QuoteConverter
+{
+    /**
+     * @var ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    public function __construct(ScopeConfigInterface $scopeConfig)
+    {
+        $this->scopeConfig = $scopeConfig;
+    }
+
+    /**
+     * @return array<string, string|array<string, array<string, string|float|array<string, string|float>>>>
+     */
+    public function convertFullQuote(Quote $quote, string $gatewayId): array
+    {
+        return array_merge_recursive(
+            $this->convertGatewayIdentifier($gatewayId),
+            $this->convertLocale($quote),
+            $this->convertCustomer($quote),
+            $this->convertShippingInformation($quote),
+            $this->convertQuoteItems($quote),
+            $this->convertTotal($quote),
+            $this->convertTaxes($quote),
+            $this->convertDiscount($quote)
+        );
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function convertGatewayIdentifier(string $gatewayId): array
+    {
+        return [
+            'gateway_id' => $gatewayId
+        ];
+    }
+
+    /**
+     * @return array<string, array<string, string>>
+     */
+    public function convertLocale(Quote $quote): array
+    {
+        /** @var string|null $locale */
+        $locale = $this->scopeConfig->getValue(
+            'general/locale/code',
+            ScopeInterface::SCOPE_STORES,
+            $quote->getStoreId()
+        );
+
+        return [
+            'order_data' => [
+                'locale' => str_replace('_', '-', $locale ?? '')
+            ]
+        ];
+    }
+
+    /**
+     * @return array<string, array<string, array<string, string>>>
+     */
+    public function convertCustomer(Quote $quote): array
+    {
+        $billingAddress = $quote->getBillingAddress();
+
+        return [
+            'order_data' => [
+                'customer' => [
+                    'first_name' => $billingAddress->getFirstname() ?? '',
+                    'last_name' => $billingAddress->getLastname() ?? '',
+                    'email' => $billingAddress->getEmail() ?? ''
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * @return array<string, array<string, array<array<string, array<string, string>|string>|string>>>
+     */
+    public function convertShippingInformation(Quote $quote): array
+    {
+        if ($quote->getIsVirtual()) {
+            return [];
+        }
+
+        $currencyCode = $quote->getCurrency() !== null ? $quote->getCurrency()->getQuoteCurrencyCode() : '';
+        $shippingAddress = $quote->getShippingAddress();
+
+        $shippingAddress->setCollectShippingRates(true);
+        $shippingAddress->collectShippingRates();
+
+        /** @var Rate[] $shippingRates */
+        $shippingRates = $shippingAddress->getShippingRatesCollection()->getItems();
+
+        return [
+            'order_data' => [
+                'shipping_address' => [
+                    'address_line_1' => $shippingAddress->getStreet()[0] ?? '',
+                    'address_line_2' => $shippingAddress->getStreet()[1] ?? '',
+                    'city' => $shippingAddress->getCity() ?? '',
+                    'country_code' => $shippingAddress->getCountryId() ?? '',
+                    'postal_code' => $shippingAddress->getPostcode() ?? '',
+                    'state' => $shippingAddress->getRegion() ?? ''
+                ],
+                'selected_shipping_option' => [
+                    'label' => $shippingAddress->getShippingDescription(),
+                    'type' => 'SHIPPING',
+                    'amount' => [
+                        'currency_code' => $currencyCode ?? '',
+                        'value' => number_format((float)$shippingAddress->getShippingAmount(), 2)
+                    ],
+                ],
+                'shipping_options' => array_map(
+                    static function (Rate $rate) use ($currencyCode): array {
+                        return [
+                            'label' => trim("{$rate->getCarrierTitle()} - {$rate->getMethodTitle()}", ' -'),
+                            'type' => 'SHIPPING',
+                            'amount' => [
+                                'currency_code' => $currencyCode ?? '',
+                                'value' => number_format((float)$rate->getPrice(), 2)
+                            ]
+                        ];
+                    },
+                    $shippingRates
+                )
+            ]
+        ];
+    }
+
+    /**
+     * @return array<string, array<string, array<array<string, array<string, string>|bool|int|string>>>>
+     */
+    public function convertQuoteItems(Quote $quote): array
+    {
+        if ($quote->getItems() === null) {
+            return [];
+        }
+
+        $currencyCode = $quote->getCurrency() !== null ? $quote->getCurrency()->getQuoteCurrencyCode() : '';
+
+        return [
+            'order_data' => [
+                'items' => array_map(
+                    static function (CartItemInterface $cartItem) use ($currencyCode): array {
+                        return [
+                            'name' => $cartItem->getName() ?? '',
+                            'sku' => $cartItem->getSku() ?? '',
+                            'unit_amount' => [
+                                'currency_code' => $currencyCode ?? '',
+                                'value' => number_format((float)$cartItem->getPrice(), 2)
+                            ],
+                            'quantity' => (int)(ceil($cartItem->getQty()) ?: $cartItem->getQty()),
+                            'is_shipping_required' => !in_array(
+                                $cartItem->getProductType(),
+                                [
+                                    'virtual',
+                                    'downloadable',
+                                    // TODO: add virtual gift cards to this list (Adobe Commerce only)
+                                ],
+                                true
+                            ),
+                        ];
+                    },
+                    $quote->getItems()
+                )
+            ]
+        ];
+    }
+
+    /**
+     * @return array<string, array<string, array<string, string>>>
+     */
+    public function convertTotal(Quote $quote): array
+    {
+        $currencyCode = $quote->getCurrency() !== null ? $quote->getCurrency()->getQuoteCurrencyCode() : '';
+
+        $quote->collectTotals(); // Ensure that we have the correct grand total for the quote
+
+        return [
+            'order_data' => [
+                'amount' => [
+                    'currency_code' => $currencyCode ?? '',
+                    'value' => number_format((float)$quote->getGrandTotal(), 2)
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * @return array<string, array<string, array<string, string>>>
+     */
+    public function convertTaxes(Quote $quote): array
+    {
+        $currencyCode = $quote->getCurrency() !== null ? $quote->getCurrency()->getQuoteCurrencyCode() : '';
+        $convertedQuote = [
+            'order_data' => [
+                'tax_total' => [
+                    'currency_code' => $currencyCode ?? '',
+                    'value' => ''
+                ]
+            ]
+        ];
+
+        if ($quote->getIsVirtual()) {
+            /** @var Item[] $items */
+            $items = $quote->getItems();
+            $convertedQuote['order_data']['tax_total']['value'] = number_format(
+                array_sum(
+                    array_map(
+                        static function (Item $item): float {
+                            return $item->getTaxAmount() ?? 0.00;
+                        },
+                        $items
+                    )
+                ),
+                2
+            );
+        } else {
+            $convertedQuote['order_data']['tax_total']['value'] = number_format(
+                (float)$quote->getShippingAddress()->getTaxAmount(),
+                2
+            );
+        }
+
+        return $convertedQuote;
+    }
+
+    /**
+     * @return array<string, array<string, array<string, string>>>
+     */
+    public function convertDiscount(Quote $quote): array
+    {
+        $currencyCode = $quote->getCurrency() !== null ? $quote->getCurrency()->getQuoteCurrencyCode() : '';
+
+        return [
+            'order_data' => [
+                'discount' => [
+                    'currency_code' => $currencyCode ?? '',
+                    'value' => number_format((float)($quote->getSubtotal() - $quote->getSubtotalWithDiscount()), 2)
+                ]
+            ]
+        ];
+    }
+}

--- a/Service/ExpressPay/QuoteConverter.php
+++ b/Service/ExpressPay/QuoteConverter.php
@@ -123,6 +123,7 @@ class QuoteConverter
             'order_data' => [
                 'shipping_address' => [],
                 'selected_shipping_option' => [
+                    'id' => $shippingAddress->getShippingMethod(),
                     'label' => $shippingAddress->getShippingDescription(),
                     'type' => 'SHIPPING',
                     'amount' => [
@@ -133,6 +134,7 @@ class QuoteConverter
                 'shipping_options' => array_map(
                     static function (Rate $rate) use ($currencyCode): array {
                         return [
+                            'id' => $rate->getCode(),
                             'label' => trim("{$rate->getCarrierTitle()} - {$rate->getMethodTitle()}", ' -'),
                             'type' => 'SHIPPING',
                             'amount' => [

--- a/Service/ExpressPay/QuoteConverter.php
+++ b/Service/ExpressPay/QuoteConverter.php
@@ -104,7 +104,7 @@ class QuoteConverter
     /**
      * @return array<string, array<string, array<array<string, array<string, string>|string>|string>>>
      */
-    public function convertShippingInformation(Quote $quote): array
+    public function convertShippingInformation(Quote $quote, bool $includeAddress = true): array
     {
         if ($quote->getIsVirtual()) {
             return [];
@@ -119,16 +119,9 @@ class QuoteConverter
         /** @var Rate[] $shippingRates */
         $shippingRates = $shippingAddress->getShippingRatesCollection()->getItems();
 
-        return [
+        $convertedQuote = [
             'order_data' => [
-                'shipping_address' => [
-                    'address_line_1' => $shippingAddress->getStreet()[0] ?? '',
-                    'address_line_2' => $shippingAddress->getStreet()[1] ?? '',
-                    'city' => $shippingAddress->getCity() ?? '',
-                    'country_code' => $shippingAddress->getCountryId() ?? '',
-                    'postal_code' => $shippingAddress->getPostcode() ?? '',
-                    'state' => $shippingAddress->getRegion() ?? ''
-                ],
+                'shipping_address' => [],
                 'selected_shipping_option' => [
                     'label' => $shippingAddress->getShippingDescription(),
                     'type' => 'SHIPPING',
@@ -152,6 +145,19 @@ class QuoteConverter
                 )
             ]
         ];
+
+        if ($includeAddress) {
+            $convertedQuote['order_data']['shipping_address'] = [
+                'address_line_1' => $shippingAddress->getStreet()[0] ?? '',
+                'address_line_2' => $shippingAddress->getStreet()[1] ?? '',
+                'city' => $shippingAddress->getCity() ?? '',
+                'country_code' => $shippingAddress->getCountryId() ?? '',
+                'postal_code' => $shippingAddress->getPostcode() ?? '',
+                'state' => $shippingAddress->getRegion() ?? ''
+            ];
+        }
+
+        return $convertedQuote;
     }
 
     /**

--- a/Test/Integration/Service/ExpressPay/Order/CreateTest.php
+++ b/Test/Integration/Service/ExpressPay/Order/CreateTest.php
@@ -34,8 +34,6 @@ class CreateTest extends TestCase
      */
     public function testCreatesExpressPayOrderSuccessfully(): void
     {
-        $this->expectNotToPerformAssertions();
-
         $boldApiResultMock = $this->createMock(ResultInterface::class);
         $boldClientMock = $this->createMock(BoldClient::class);
         /** @var ObjectManagerInterface $objectManager */
@@ -49,6 +47,15 @@ class CreateTest extends TestCase
         );
         $quoteMaskId = $this->getQuoteMaskId();
 
+        $boldApiResultMock->method('getBody')
+            ->willReturn(
+                [
+                    'data' => [
+                        'order_id' => '5d23799a-0c98-4147-914e-abd1b84aab82'
+                    ]
+                ]
+            );
+
         $boldApiResultMock->method('getErrors')
             ->willReturn([]);
 
@@ -58,7 +65,15 @@ class CreateTest extends TestCase
         $boldClientMock->method('post')
             ->willReturn($boldApiResultMock);
 
-        $createExpressPayOrderService->execute($quoteMaskId, 'e4403e69-1fd2-4d8a-be28-fdbf911a20bb');
+        $expectedResultData = [
+            'paypal_order_id' => '5d23799a-0c98-4147-914e-abd1b84aab82'
+        ];
+        $actualResultData = $createExpressPayOrderService->execute(
+            $quoteMaskId,
+            'e4403e69-1fd2-4d8a-be28-fdbf911a20bb'
+        );
+
+        self::assertSame($expectedResultData, $actualResultData);
     }
 
     public function testDoesNotCreateExpressPayOrderIfQuoteMaskIdIsInvalid(): void

--- a/Test/Integration/Service/ExpressPay/Order/CreateTest.php
+++ b/Test/Integration/Service/ExpressPay/Order/CreateTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\CheckoutPaymentBooster\Test\Integration\Service\ExpressPay\Order;
+
+use Bold\Checkout\Api\Data\Http\Client\ResultInterface;
+use Bold\Checkout\Model\Http\BoldClient;
+use Bold\CheckoutPaymentBooster\Service\ExpressPay\Order\Create;
+use Exception;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\ObjectManagerInterface;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Api\Data\CartInterface;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\QuoteIdToMaskedQuoteIdInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+use function reset;
+
+class CreateTest extends TestCase
+{
+    /**
+     * @var Quote|null
+     */
+    private $quote;
+
+    /**
+     * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/quote_with_shipping_tax_and_discount.php
+     * @throws LocalizedException
+     */
+    public function testCreatesExpressPayOrderSuccessfully(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $boldApiResultMock = $this->createMock(ResultInterface::class);
+        $boldClientMock = $this->createMock(BoldClient::class);
+        /** @var ObjectManagerInterface $objectManager */
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var Create $createExpressPayOrderService */
+        $createExpressPayOrderService = $objectManager->create(
+            Create::class,
+            [
+                'httpClient' => $boldClientMock
+            ]
+        );
+        $quoteMaskId = $this->getQuoteMaskId();
+
+        $boldApiResultMock->method('getErrors')
+            ->willReturn([]);
+
+        $boldApiResultMock->method('getStatus')
+            ->willReturn(201);
+
+        $boldClientMock->method('post')
+            ->willReturn($boldApiResultMock);
+
+        $createExpressPayOrderService->execute($quoteMaskId, 'e4403e69-1fd2-4d8a-be28-fdbf911a20bb');
+    }
+
+    public function testDoesNotCreateExpressPayOrderIfQuoteMaskIdIsInvalid(): void
+    {
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessage(
+            'Could not create Express Pay order. Invalid quote mask ID "bb567af9f9d44983971981a6e8eacfd6".'
+        );
+
+        /** @var ObjectManagerInterface $objectManager */
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var Create $createExpressPayOrderService */
+        $createExpressPayOrderService = $objectManager->create(Create::class);
+
+        $createExpressPayOrderService->execute(
+            'bb567af9f9d44983971981a6e8eacfd6',
+            '525f40b7-c512-4e5b-aa82-cc7276a48de9'
+        );
+    }
+
+    public function testDoesNotCreateExpressPayOrderIfQuoteDoesNotExist(): void
+    {
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessage('Could not create Express Pay order. Invalid quote ID "42".');
+
+        /** @var ObjectManagerInterface $objectManager */
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var Create $createExpressPayOrderService */
+        $createExpressPayOrderService = $objectManager->create(Create::class);
+
+        $createExpressPayOrderService->execute(42, '525f40b7-c512-4e5b-aa82-cc7276a48de9');
+    }
+
+    /**
+     * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/quote_with_shipping_tax_and_discount.php
+     */
+    public function testThrowsExceptionIfApiCallThrowsException(): void
+    {
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessage('Could not create Express Pay order. Error: "HTTP 503 Service Unavailable"');
+
+        $boldClientMock = $this->createMock(BoldClient::class);
+        /** @var ObjectManagerInterface $objectManager */
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var Create $createExpressPayOrderService */
+        $createExpressPayOrderService = $objectManager->create(
+            Create::class,
+            [
+                'httpClient' => $boldClientMock
+            ]
+        );
+        $quoteMaskId = $this->getQuoteMaskId();
+
+        $boldClientMock->method('post')
+            ->willThrowException(new Exception('HTTP 503 Service Unavailable'));
+
+        $createExpressPayOrderService->execute($quoteMaskId, 'ae066eda-f88a-4c13-938f-e8bd4e496144');
+    }
+
+    /**
+     * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/quote_with_shipping_tax_and_discount.php
+     */
+    public function testThrowsExceptionIfApiCallReturnsIncorrectStatus(): void
+    {
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessage('An unknown error occurred while creating the Express Pay order.');
+
+        $boldApiResultMock = $this->createMock(ResultInterface::class);
+        $boldClientMock = $this->createMock(BoldClient::class);
+        /** @var ObjectManagerInterface $objectManager */
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var Create $createExpressPayOrderService */
+        $createExpressPayOrderService = $objectManager->create(
+            Create::class,
+            [
+                'httpClient' => $boldClientMock
+            ]
+        );
+        $quoteMaskId = $this->getQuoteMaskId();
+
+        $boldApiResultMock->method('getErrors')
+            ->willReturn([]);
+
+        $boldApiResultMock->method('getStatus')
+            ->willReturn(422);
+
+        $boldClientMock->method('post')
+            ->willReturn($boldApiResultMock);
+
+        $createExpressPayOrderService->execute($quoteMaskId, 'ae066eda-f88a-4c13-938f-e8bd4e496144');
+    }
+
+    private function getQuote(): Quote
+    {
+        if ($this->quote !== null) {
+            return $this->quote;
+        }
+
+        /** @var ObjectManagerInterface $objectManager */
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var SearchCriteriaBuilder $searchCriteriaBuilder */
+        $searchCriteriaBuilder = $objectManager->create(SearchCriteriaBuilder::class);
+        $searchCriteria = $searchCriteriaBuilder->addFilter('reserved_order_id', 'test_order_1')
+            ->create();
+        /** @var CartRepositoryInterface $cartRepository */
+        $cartRepository = $objectManager->create(CartRepositoryInterface::class);
+        /** @var Quote[] $quotes */
+        $quotes = $cartRepository->getList($searchCriteria)
+            ->getItems();
+        /** @var Quote $quote */
+        $quote = reset($quotes) ?: $objectManager->create(CartInterface::class);
+
+        return $this->quote = $quote;
+    }
+
+    private function getQuoteMaskId(): string
+    {
+        /** @var ObjectManagerInterface $objectManager */
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var QuoteIdToMaskedQuoteIdInterface $quoteIdToMaskedQuoteId */
+        $quoteIdToMaskedQuoteId = $objectManager->create(QuoteIdToMaskedQuoteIdInterface::class);
+        /** @var int|string|null $quoteId */
+        $quoteId = $this->getQuote()->getId();
+
+        try {
+            $quoteMaskId = $quoteIdToMaskedQuoteId->execute((int)$quoteId);
+        } catch (NoSuchEntityException $e) {
+            $quoteMaskId = '';
+        }
+
+        return $quoteMaskId;
+    }
+}

--- a/Test/Integration/Service/ExpressPay/Order/CreateTest.php
+++ b/Test/Integration/Service/ExpressPay/Order/CreateTest.php
@@ -53,7 +53,7 @@ class CreateTest extends TestCase
             ->willReturn([]);
 
         $boldApiResultMock->method('getStatus')
-            ->willReturn(201);
+            ->willReturn(200);
 
         $boldClientMock->method('post')
             ->willReturn($boldApiResultMock);

--- a/Test/Integration/Service/ExpressPay/Order/GetTest.php
+++ b/Test/Integration/Service/ExpressPay/Order/GetTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\CheckoutPaymentBooster\Test\Integration\Service\ExpressPay\Order;
+
+use Bold\Checkout\Api\Data\Http\Client\ResultInterface;
+use Bold\Checkout\Model\Http\BoldClient;
+use Bold\CheckoutPaymentBooster\Service\ExpressPay\Order\Get;
+use Exception;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\ObjectManagerInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+class GetTest extends TestCase
+{
+    /**
+     * @throws LocalizedException
+     */
+    public function testGetsExpressPayOrderSuccessfully(): void
+    {
+        $expressPayOrderData = [
+            'first_name' => 'John',
+            'last_name' => 'Smith',
+            'email' => 'jsmithn@example.com',
+            'shipping_address' => [
+                'address_line_1' => '123 Example Street',
+                'address_line_2' => 'Unit 42',
+                'city' => 'Some City',
+                'country' => 'US',
+                'province' => 'SS',
+                'postal_code' => '01234',
+                'phone' => '123-456-7890'
+            ],
+            'billing_address' => [
+                'address_line_1' => '123 Example Street',
+                'address_line_2' => 'Unit 42',
+                'city' => 'Some City',
+                'country' => 'US',
+                'province' => 'SS',
+                'postal_code' => '01234',
+                'phone' => '123-456-7890'
+            ]
+        ];
+        $boldApiResultMock = $this->createMock(ResultInterface::class);
+        $boldClientMock = $this->createMock(BoldClient::class);
+        /** @var ObjectManagerInterface $objectManager */
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var Get $getExpressPayOrderService */
+        $getExpressPayOrderService = $objectManager->create(
+            Get::class,
+            [
+                'httpClient' => $boldClientMock
+            ]
+        );
+
+        $boldApiResultMock->method('getBody')
+            ->willReturn($expressPayOrderData);
+
+        $boldApiResultMock->method('getErrors')
+            ->willReturn([]);
+
+        $boldApiResultMock->method('getStatus')
+            ->willReturn(200);
+
+        $boldClientMock->method('get')
+            ->willReturn($boldApiResultMock);
+
+        $actualExpressPayOrderData = $getExpressPayOrderService->execute(
+            'c7215964-94b5-4a64-8e5d-152ad284cedf',
+            '87ef83fe-b43c-4c40-9c96-1413b9d11b79'
+        );
+
+        self::assertSame($expressPayOrderData, $actualExpressPayOrderData);
+    }
+
+    public function testThrowsExceptionIfApiCallThrowsException(): void
+    {
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessage('Could not get Express Pay order. Error: "HTTP 503 Service Unavailable"');
+
+        $boldClientMock = $this->createMock(BoldClient::class);
+        /** @var ObjectManagerInterface $objectManager */
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var Get $getExpressPayOrderService */
+        $getExpressPayOrderService = $objectManager->create(
+            Get::class,
+            [
+                'httpClient' => $boldClientMock
+            ]
+        );
+
+        $boldClientMock->method('get')
+            ->willThrowException(new Exception('HTTP 503 Service Unavailable'));
+
+        $getExpressPayOrderService->execute(
+            '2765b685-4623-4089-9bb1-b85d6853149b',
+            'e072601d-8723-4746-b43b-a7a17b833cfd'
+        );
+    }
+
+    /**
+     * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/quote_with_shipping_tax_and_discount.php
+     */
+    public function testThrowsExceptionIfApiCallReturnsIncorrectStatus(): void
+    {
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessage('An unknown error occurred while getting the Express Pay order.');
+
+        $boldApiResultMock = $this->createMock(ResultInterface::class);
+        $boldClientMock = $this->createMock(BoldClient::class);
+        /** @var ObjectManagerInterface $objectManager */
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var Get $getExpressPayOrderService */
+        $getExpressPayOrderService = $objectManager->create(
+            Get::class,
+            [
+                'httpClient' => $boldClientMock
+            ]
+        );
+
+        $boldApiResultMock->method('getErrors')
+            ->willReturn([]);
+
+        $boldApiResultMock->method('getStatus')
+            ->willReturn(422);
+
+        $boldClientMock->method('get')
+            ->willReturn($boldApiResultMock);
+
+        $getExpressPayOrderService->execute(
+            '64082511-1cfd-4772-b0c1-250871f738d4',
+            '582e95b1-1a45-4b85-8d0c-b71850e986cd'
+        );
+    }
+}

--- a/Test/Integration/Service/ExpressPay/Order/UpdateTest.php
+++ b/Test/Integration/Service/ExpressPay/Order/UpdateTest.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\CheckoutPaymentBooster\Test\Integration\Service\ExpressPay\Order;
+
+use Bold\Checkout\Api\Data\Http\Client\ResultInterface;
+use Bold\Checkout\Model\Http\BoldClient;
+use Bold\CheckoutPaymentBooster\Service\ExpressPay\Order\Update;
+use Exception;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\ObjectManagerInterface;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Api\Data\CartInterface;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\QuoteIdToMaskedQuoteIdInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+use function reset;
+
+class UpdateTest extends TestCase
+{
+    /**
+     * @var Quote|null
+     */
+    private $quote;
+
+    /**
+     * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/quote_with_shipping_tax_and_discount.php
+     * @throws LocalizedException
+     */
+    public function testUpdatesExpressPayOrderSuccessfully(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $boldApiResultMock = $this->createMock(ResultInterface::class);
+        $boldClientMock = $this->createMock(BoldClient::class);
+        /** @var ObjectManagerInterface $objectManager */
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var Update $updateExpressPayOrderService */
+        $updateExpressPayOrderService = $objectManager->create(
+            Update::class,
+            [
+                'httpClient' => $boldClientMock
+            ]
+        );
+        $quoteMaskId = $this->getQuoteMaskId();
+
+        $boldApiResultMock->method('getErrors')
+            ->willReturn([]);
+
+        $boldApiResultMock->method('getStatus')
+            ->willReturn(204);
+
+        $boldClientMock->method('patch')
+            ->willReturn($boldApiResultMock);
+
+        $updateExpressPayOrderService->execute($quoteMaskId, 'e08fac5cffd6467389ce3aac1df1eeeb');
+    }
+
+    public function testDoesNotUpdateExpressPayOrderIfQuoteMaskIdIsInvalid(): void
+    {
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessage(
+            'Could not update Express Pay order. Invalid quote mask ID "d3b46018dbff492d8ad339229f9a30f7".'
+        );
+
+        /** @var ObjectManagerInterface $objectManager */
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var Update $updateExpressPayOrderService */
+        $updateExpressPayOrderService = $objectManager->create(Update::class);
+
+        $updateExpressPayOrderService->execute('d3b46018dbff492d8ad339229f9a30f7', '97fb04bc9669476bb271985ffa1875d9');
+    }
+
+    public function testDoesNotUpdateExpressPayOrderIfQuoteDoesNotExist(): void
+    {
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessage('Could not update Express Pay order. Invalid quote ID "42".');
+
+        /** @var ObjectManagerInterface $objectManager */
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var Update $updateExpressPayOrderService */
+        $updateExpressPayOrderService = $objectManager->create(Update::class);
+
+        $updateExpressPayOrderService->execute(42, 'b76f88547476441a88c81fa0905d4505');
+    }
+
+    /**
+     * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/quote_with_shipping_tax_and_discount.php
+     */
+    public function testThrowsExceptionIfApiCallThrowsException(): void
+    {
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessage('Could not update Express Pay order. Error: "HTTP 503 Service Unavailable"');
+
+        $boldClientMock = $this->createMock(BoldClient::class);
+        /** @var ObjectManagerInterface $objectManager */
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var Update $updateExpressPayOrderService */
+        $updateExpressPayOrderService = $objectManager->create(
+            Update::class,
+            [
+                'httpClient' => $boldClientMock
+            ]
+        );
+        $quoteMaskId = $this->getQuoteMaskId();
+
+        $boldClientMock->method('patch')
+            ->willThrowException(new Exception('HTTP 503 Service Unavailable'));
+
+        $updateExpressPayOrderService->execute($quoteMaskId, 'c8ced8a1f3584d378bd35fd039aeec98');
+    }
+
+    /**
+     * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/quote_with_shipping_tax_and_discount.php
+     */
+    public function testThrowsExceptionIfApiCallReturnsIncorrectStatus(): void
+    {
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessage('An unknown error occurred while updating the Express Pay order.');
+
+        $boldApiResultMock = $this->createMock(ResultInterface::class);
+        $boldClientMock = $this->createMock(BoldClient::class);
+        /** @var ObjectManagerInterface $objectManager */
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var Update $updateExpressPayOrderService */
+        $updateExpressPayOrderService = $objectManager->create(
+            Update::class,
+            [
+                'httpClient' => $boldClientMock
+            ]
+        );
+        $quoteMaskId = $this->getQuoteMaskId();
+
+        $boldApiResultMock->method('getErrors')
+            ->willReturn([]);
+
+        $boldApiResultMock->method('getStatus')
+            ->willReturn(422);
+
+        $boldClientMock->method('patch')
+            ->willReturn($boldApiResultMock);
+
+        $updateExpressPayOrderService->execute($quoteMaskId, '6622461eb1174b57b688277efc3ffb5b');
+    }
+
+    private function getQuote(): Quote
+    {
+        if ($this->quote !== null) {
+            return $this->quote;
+        }
+
+        /** @var ObjectManagerInterface $objectManager */
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var SearchCriteriaBuilder $searchCriteriaBuilder */
+        $searchCriteriaBuilder = $objectManager->create(SearchCriteriaBuilder::class);
+        $searchCriteria = $searchCriteriaBuilder->addFilter('reserved_order_id', 'test_order_1')
+            ->create();
+        /** @var CartRepositoryInterface $cartRepository */
+        $cartRepository = $objectManager->create(CartRepositoryInterface::class);
+        /** @var Quote[] $quotes */
+        $quotes = $cartRepository->getList($searchCriteria)
+            ->getItems();
+        /** @var Quote $quote */
+        $quote = reset($quotes) ?: $objectManager->create(CartInterface::class);
+
+        return $this->quote = $quote;
+    }
+
+    private function getQuoteMaskId(): string
+    {
+        /** @var ObjectManagerInterface $objectManager */
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var QuoteIdToMaskedQuoteIdInterface $quoteIdToMaskedQuoteId */
+        $quoteIdToMaskedQuoteId = $objectManager->create(QuoteIdToMaskedQuoteIdInterface::class);
+        /** @var int|string|null $quoteId */
+        $quoteId = $this->getQuote()->getId();
+
+        try {
+            $quoteMaskId = $quoteIdToMaskedQuoteId->execute((int)$quoteId);
+        } catch (NoSuchEntityException $e) {
+            $quoteMaskId = '';
+        }
+
+        return $quoteMaskId;
+    }
+}

--- a/Test/Integration/Service/ExpressPay/QuoteConverterTest.php
+++ b/Test/Integration/Service/ExpressPay/QuoteConverterTest.php
@@ -54,6 +54,7 @@ class QuoteConverterTest extends TestCase
                     'state' => 'Alabama'
                 ],
                 'selected_shipping_option' => [
+                    'id' => 'flatrate_flatrate',
                     'label' => 'Flat Rate - Fixed',
                     'type' => 'SHIPPING',
                     'amount' => [
@@ -63,6 +64,7 @@ class QuoteConverterTest extends TestCase
                 ],
                 'shipping_options' => [
                     [
+                        'id' => 'flatrate_flatrate',
                         'label' => 'Flat Rate - Fixed',
                         'type' => 'SHIPPING',
                         'amount' => [

--- a/Test/Integration/Service/ExpressPay/QuoteConverterTest.php
+++ b/Test/Integration/Service/ExpressPay/QuoteConverterTest.php
@@ -89,6 +89,10 @@ class QuoteConverterTest extends TestCase
                     'currency_code' => 'USD',
                     'value' => '26.50'
                 ],
+                'item_total' => [
+                    'currency_code' => 'USD',
+                    'value' => '20.00'
+                ],
                 'tax_total' => [
                     'currency_code' => 'USD',
                     'value' => '1.50'
@@ -169,6 +173,10 @@ class QuoteConverterTest extends TestCase
                 'amount' => [
                     'currency_code' => 'USD',
                     'value' => '5.50'
+                ],
+                'item_total' => [
+                    'currency_code' => 'USD',
+                    'value' => '10.00'
                 ],
                 'tax_total' => [
                     'currency_code' => 'USD',

--- a/Test/Integration/Service/ExpressPay/QuoteConverterTest.php
+++ b/Test/Integration/Service/ExpressPay/QuoteConverterTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\CheckoutPaymentBooster\Test\Integration\Service\ExpressPay;
+
+use Bold\CheckoutPaymentBooster\Service\ExpressPay\QuoteConverter;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Registry;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\Quote\Item;
+use Magento\Tax\Model\Calculation\Rule;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+use function array_filter;
+use function array_walk;
+use function reset;
+
+class QuoteConverterTest extends TestCase
+{
+    /**
+     * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/quote_with_shipping_tax_and_discount.php
+     */
+    public function testConvertFullQuoteConvertsNonVirtualQuote(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        $searchCriteria = $objectManager->create(SearchCriteriaBuilder::class)
+            ->addFilter('reserved_order_id', 'test_order_1')
+            ->create();
+        $quotes = $objectManager->create(CartRepositoryInterface::class)
+            ->getList($searchCriteria)
+            ->getItems();
+        /** @var Quote $quote */
+        $quote = reset($quotes) ?: $objectManager->create(Quote::class);
+        $quoteConverter = $objectManager->create(QuoteConverter::class);
+
+        $expectedConvertedQuoteData = [
+            'gateway_id' => 'a31a8fd6-a9e2-4c68-a834-54567bfeb4b7',
+            'order_data' => [
+                'locale' => 'en-US',
+                'customer' => [
+                    'first_name' => 'John',
+                    'last_name' => 'Smith',
+                    'email' => 'customer@example.com'
+                ],
+                'shipping_address' => [
+                    'address_line_1' => 'Green str, 67',
+                    'address_line_2' => '',
+                    'city' => 'CityM',
+                    'country_code' => 'US',
+                    'postal_code' => '75477',
+                    'state' => 'Alabama'
+                ],
+                'selected_shipping_option' => [
+                    'label' => 'Flat Rate - Fixed',
+                    'type' => 'SHIPPING',
+                    'amount' => [
+                        'currency_code' => 'USD',
+                        'value' => '10.00'
+                    ]
+                ],
+                'shipping_options' => [
+                    [
+                        'label' => 'Flat Rate - Fixed',
+                        'type' => 'SHIPPING',
+                        'amount' => [
+                            'currency_code' => 'USD',
+                            'value' => '10.00'
+                        ]
+                    ]
+                ],
+                'items' => [
+                    [
+                        'name' => 'Simple Product',
+                        'sku' => 'simple',
+                        'unit_amount' => [
+                            'currency_code' => 'USD',
+                            'value' => '10.00'
+                        ],
+                        'quantity' => 2,
+                        'is_shipping_required' => true
+                    ]
+                ],
+                'amount' => [
+                    'currency_code' => 'USD',
+                    'value' => '26.50'
+                ],
+                'tax_total' => [
+                    'currency_code' => 'USD',
+                    'value' => '1.50'
+                ],
+                'discount' => [
+                    'currency_code' => 'USD',
+                    'value' => '5.00'
+                ]
+            ]
+        ];
+        $actualConvertedQuoteData = $quoteConverter->convertFullQuote($quote, 'a31a8fd6-a9e2-4c68-a834-54567bfeb4b7');
+
+        self::assertEquals($expectedConvertedQuoteData, $actualConvertedQuoteData);
+    }
+
+    /**
+     * @magentoDataFixture Magento/ConfigurableProduct/_files/tax_rule.php
+     * @magentoDataFixture Magento/SalesRule/_files/cart_rule_with_coupon_5_off_no_condition.php
+     * @magentoDataFixture Magento/Checkout/_files/quote_with_virtual_product_saved.php
+     */
+    public function testConvertFullQuoteConvertsVirtualQuote(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        $searchCriteria = $objectManager->create(SearchCriteriaBuilder::class)
+            ->addFilter('reserved_order_id', 'test_order_with_virtual_product_without_address')
+            ->create();
+        /** @var CartRepositoryInterface $cartRepository */
+        $cartRepository = $objectManager->create(CartRepositoryInterface::class);
+        $quotes = $cartRepository->getList($searchCriteria)->getItems();
+        /** @var Quote $quote */
+        $quote = reset($quotes) ?: $objectManager->create(Quote::class);
+        /** @var Item[] $quoteItems */
+        $quoteItems = $quote->getAllItems();
+        /** @var Registry $registry */
+        $registry = $objectManager->get(Registry::class);
+        /** @var Rule $taxRule */
+        $taxRule = $registry->registry('_fixture/Magento_Tax_Model_Calculation_Rule');
+        $quoteConverter = $objectManager->create(QuoteConverter::class);
+
+        array_walk(
+            $quoteItems,
+            static function (Item $item) use ($taxRule): void {
+                $item->getProduct()
+                    ->setTaxClassId($taxRule->getProductTaxClassIds()[0])
+                    ->save();
+            }
+        );
+
+        $quote->setCouponCode('CART_FIXED_DISCOUNT_5');
+        $quote->getBillingAddress()
+            ->setFirstname('John')
+            ->setLastname('Smith')
+            ->setEmail('customer@example.com');
+
+        $cartRepository->save($quote);
+
+        $expectedConvertedQuoteData = [
+            'gateway_id' => 'a31a8fd6-a9e2-4c68-a834-54567bfeb4b7',
+            'order_data' => [
+                'locale' => 'en-US',
+                'customer' => [
+                    'first_name' => 'John',
+                    'last_name' => 'Smith',
+                    'email' => 'customer@example.com'
+                ],
+                'items' => [
+                    [
+                        'name' => 'Virtual Product',
+                        'sku' => 'virtual-product',
+                        'unit_amount' => [
+                            'currency_code' => 'USD',
+                            'value' => '10.00'
+                        ],
+                        'quantity' => 1,
+                        'is_shipping_required' => false
+                    ]
+                ],
+                'amount' => [
+                    'currency_code' => 'USD',
+                    'value' => '5.50'
+                ],
+                'tax_total' => [
+                    'currency_code' => 'USD',
+                    'value' => '0.50'
+                ],
+                'discount' => [
+                    'currency_code' => 'USD',
+                    'value' => '5.00'
+                ]
+            ]
+        ];
+        $actualConvertedQuoteData = array_filter(
+            $quoteConverter->convertFullQuote(
+                $quote,
+                'a31a8fd6-a9e2-4c68-a834-54567bfeb4b7'
+            )
+        );
+
+        self::assertEquals($expectedConvertedQuoteData, $actualConvertedQuoteData);
+    }
+}

--- a/Test/Integration/_files/quote_with_shipping_tax_and_discount.php
+++ b/Test/Integration/_files/quote_with_shipping_tax_and_discount.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use Magento\Framework\Registry;
+use Magento\Quote\Model\Quote\Address\Rate;
+use Magento\Quote\Model\Quote\Item;
+use Magento\Quote\Model\QuoteFactory;
+use Magento\Quote\Model\ResourceModel\Quote as QuoteResource;
+use Magento\Tax\Model\Calculation\Rule;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\TestFramework\Workaround\Override\Fixture\Resolver;
+
+Resolver::getInstance()->requireDataFixture('Magento/ConfigurableProduct/_files/tax_rule.php');
+Resolver::getInstance()->requireDataFixture('Magento/SalesRule/_files/cart_rule_with_coupon_5_off_no_condition.php');
+Resolver::getInstance()->requireDataFixture('Magento/Checkout/_files/quote_with_address_saved.php');
+
+$objectManager = Bootstrap::getObjectManager();
+/** @var QuoteFactory $quoteFactory */
+$quoteFactory = $objectManager->get(QuoteFactory::class);
+/** @var QuoteResource $quoteResource */
+$quoteResource = $objectManager->get(QuoteResource::class);
+$quote = $quoteFactory->create();
+
+$quoteResource->load($quote, 'test_order_1', 'reserved_order_id');
+
+$shippingAddress = $quote->getShippingAddress();
+
+$shippingAddress->setShippingMethod('flatrate_flatrate')
+    ->setShippingDescription('Flat Rate - Fixed')
+    ->save();
+
+$rate = $objectManager->get(Rate::class);
+
+$rate->setPrice(5.00)
+    ->setAddressId($shippingAddress->getId())
+    ->save();
+
+$shippingAddress->setBaseShippingAmount($rate->getPrice());
+$shippingAddress->setShippingAmount($rate->getPrice());
+
+$rate->delete();
+
+$registry = $objectManager->get(Registry::class);
+/** @var Rule $taxRule */
+$taxRule = $registry->registry('_fixture/Magento_Tax_Model_Calculation_Rule');
+/** @var Item[] $quoteItems */
+$quoteItems = $quote->getAllItems();
+
+array_walk(
+    $quoteItems,
+    static function (Item $item) use ($taxRule): void {
+        $item->getProduct()
+            ->setTaxClassId($taxRule->getProductTaxClassIds()[0])
+            ->save();
+    }
+);
+
+$quote->setCouponCode('CART_FIXED_DISCOUNT_5');
+$quote->save();

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
   "version": "1.1.0",
   "require": {
     "magento/framework": ">=102.0.1 <103.0.8",
+    "magento/module-checkout": ">=100.3.1 <100.4.8",
     "magento/module-quote": ">=101.1.1 <101.2.8",
     "magento/module-store": ">=101.0.1 <101.1.8",
     "bold-commerce/module-checkout": "^2.0.0"

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,8 @@
   "version": "1.1.0",
   "require": {
     "magento/framework": ">=102.0.1 <103.0.8",
+    "magento/module-quote": ">=101.1.1 <101.2.8",
+    "magento/module-store": ">=101.0.1 <101.1.8",
     "bold-commerce/module-checkout": "^2.0.0"
   },
   "autoload": {

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -86,6 +86,12 @@
         </arguments>
     </type>
 
+    <type name="Bold\CheckoutPaymentBooster\Service\ExpressPay\Order\Update">
+        <arguments>
+            <argument name="httpClient" xsi:type="object">Bold\Checkout\Model\Http\BoldClient</argument>
+        </arguments>
+    </type>
+
     <type name="Magento\Webapi\Controller\Rest\ParamsOverrider">
         <arguments>
             <argument name="paramOverriders" xsi:type="array">

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -79,4 +79,18 @@
     <type name="Magento\Quote\Model\QuoteManagement">
         <plugin name="disable_fastlane_address_validation" type="Bold\CheckoutPaymentBooster\Plugin\Quote\Model\QuoteManagement\DisableFastlaneAddressValidationPlugin" />
     </type>
+
+    <type name="Bold\CheckoutPaymentBooster\Service\ExpressPay\Order\Create">
+        <arguments>
+            <argument name="httpClient" xsi:type="object">Bold\Checkout\Model\Http\BoldClient</argument>
+        </arguments>
+    </type>
+
+    <type name="Magento\Webapi\Controller\Rest\ParamsOverrider">
+        <arguments>
+            <argument name="paramOverriders" xsi:type="array">
+                <item name="%quote_mask_id%" xsi:type="object">Magento\Quote\Model\Webapi\ParamOverriderCartId\Proxy</item>
+            </argument>
+        </arguments>
+    </type>
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -92,6 +92,12 @@
         </arguments>
     </type>
 
+    <type name="Bold\CheckoutPaymentBooster\Service\ExpressPay\Order\Get">
+        <arguments>
+            <argument name="httpClient" xsi:type="object">Bold\Checkout\Model\Http\BoldClient</argument>
+        </arguments>
+    </type>
+
     <type name="Magento\Webapi\Controller\Rest\ParamsOverrider">
         <arguments>
             <argument name="paramOverriders" xsi:type="array">

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -4,6 +4,8 @@
     <module name="Bold_CheckoutPaymentBooster">
         <sequence>
             <module name="Bold_Checkout"/>
+            <module name="Magento_Quote"/>
+            <module name="Magento_Store"/>
         </sequence>
     </module>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -4,6 +4,7 @@
     <module name="Bold_CheckoutPaymentBooster">
         <sequence>
             <module name="Bold_Checkout"/>
+            <module name="Magento_Checkout"/>
             <module name="Magento_Quote"/>
             <module name="Magento_Store"/>
         </sequence>

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Webapi:etc/webapi.xsd">
+    <route url="/V1/express_pay/order/create" method="POST">
+        <service class="Bold\CheckoutPaymentBooster\Service\ExpressPay\Order\Create" method="execute"/>
+        <resources>
+            <resource ref="anonymous"/>
+        </resources>
+    </route>
+    <route url="/V1/express_pay/order/create/mine" method="POST">
+        <service class="Bold\CheckoutPaymentBooster\Service\ExpressPay\Order\Create" method="execute"/>
+        <resources>
+            <resource ref="self"/>
+        </resources>
+        <data>
+            <parameter name="quoteMaskId" force="true">%quote_mask_id%</parameter>
+        </data>
+    </route>
+</routes>

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -15,4 +15,19 @@
             <parameter name="quoteMaskId" force="true">%quote_mask_id%</parameter>
         </data>
     </route>
+    <route url="/V1/express_pay/order/update" method="POST">
+        <service class="Bold\CheckoutPaymentBooster\Service\ExpressPay\Order\Update" method="execute"/>
+        <resources>
+            <resource ref="anonymous"/>
+        </resources>
+    </route>
+    <route url="/V1/express_pay/order/mine/update" method="POST">
+        <service class="Bold\CheckoutPaymentBooster\Service\ExpressPay\Order\Update" method="execute"/>
+        <resources>
+            <resource ref="self"/>
+        </resources>
+        <data>
+            <parameter name="quoteMaskId" force="true">%quote_mask_id%</parameter>
+        </data>
+    </route>
 </routes>

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -6,7 +6,7 @@
             <resource ref="anonymous"/>
         </resources>
     </route>
-    <route url="/V1/express_pay/order/create/mine" method="POST">
+    <route url="/V1/express_pay/order/mine/create" method="POST">
         <service class="Bold\CheckoutPaymentBooster\Service\ExpressPay\Order\Create" method="execute"/>
         <resources>
             <resource ref="self"/>

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -30,4 +30,19 @@
             <parameter name="quoteMaskId" force="true">%quote_mask_id%</parameter>
         </data>
     </route>
+    <route url="/V1/express_pay/order/get" method="POST">
+        <service class="Bold\CheckoutPaymentBooster\Service\ExpressPay\Order\Get" method="execute"/>
+        <resources>
+            <resource ref="anonymous"/>
+        </resources>
+    </route>
+    <route url="/V1/express_pay/order/mine/get" method="POST">
+        <service class="Bold\CheckoutPaymentBooster\Service\ExpressPay\Order\Get" method="execute"/>
+        <resources>
+            <resource ref="self"/>
+        </resources>
+        <data>
+            <parameter name="quoteMaskId" force="true">%quote_mask_id%</parameter>
+        </data>
+    </route>
 </routes>


### PR DESCRIPTION
Resolves [INTER-4629](https://boldapps.atlassian.net/browse/INTER-4629)
Resolves [INTER-4630](https://boldapps.atlassian.net/browse/INTER-4630)

Adds new Magento Web API endpoints for creating, updating and retrieving Express Pay (mobile wallet) orders.

| URI | Method | Parameters |Returns|
|--------|--------|--------|--------|
|/V1/express_pay/order/create | POST |`quote_mask_id`,`gateway_id`|`paypal_order_id`|
|/V1/express_pay/order/mine/create | POST |`quote_id`,`gateway_id`|`paypal_order_id`|
|/V1/express_pay/order/update | POST |`quote_mask_id`,`paypal_order_id`|VOID|
|/V1/express_pay/order/mine/update | POST |`quote_id`,`paypal_order_id`|VOID|
|/V1/express_pay/order/get | POST |`paypal_order_id`,`gateway_id`|See [spec]|
|/V1/express_pay/order/mine/get | POST |`paypal_order_id`,`gateway_id`|See [spec]|

Full [spec]

[spec]: https://github.com/bold-commerce/engineering-specs/blob/main/checkout/order/wallet-pay-helper.md
