### PR TITLE
Express Pay Shipping Address Change Callback

### DIFF
--- a/Service/ExpressPay/Order/Update.php
+++ b/Service/ExpressPay/Order/Update.php
@@ -58,11 +58,12 @@ class Update
 
     /**
      * @param string|int $quoteMaskId
+     * @param string $gatewayId
      * @param string $paypalOrderId
      * @return void
      * @throws \Magento\Framework\Exception\LocalizedException
      */
-    public function execute($quoteMaskId, $paypalOrderId): void
+    public function execute($quoteMaskId, $gatewayId, $paypalOrderId): void
     {
         if (!is_numeric($quoteMaskId) && strlen($quoteMaskId) === 32) {
             try {
@@ -85,14 +86,7 @@ class Update
 
         $websiteId = (int)$quote->getStore()->getWebsiteId();
         $uri = "/checkout/orders/{{shopId}}/wallet_pay/$paypalOrderId";
-        $expressPayData = array_merge_recursive(
-            $this->quoteConverter->convertCustomer($quote),
-            $this->quoteConverter->convertShippingInformation($quote),
-            $this->quoteConverter->convertQuoteItems($quote),
-            $this->quoteConverter->convertTotal($quote),
-            $this->quoteConverter->convertTaxes($quote),
-            $this->quoteConverter->convertDiscount($quote)
-        );
+        $expressPayData = $this->quoteConverter->convertFullQuote($quote, $gatewayId);
 
         try {
             $result = $this->httpClient->patch($websiteId, $uri, $expressPayData);

--- a/Service/ExpressPay/QuoteConverter.php
+++ b/Service/ExpressPay/QuoteConverter.php
@@ -124,7 +124,7 @@ class QuoteConverter
 
         $usedRateCodes = [];
         /** @var Rate[] $shippingRates */
-        $shippingRates = array_filter(
+        $shippingRates = array_values(array_filter(
             $shippingAddress->getShippingRatesCollection()->getItems(),
             // @phpstan-ignore argument.type
             static function (Rate $rate) use (&$usedRateCodes): bool {
@@ -136,7 +136,7 @@ class QuoteConverter
 
                 return true;
             }
-        ); // Work-around for Magento bug causing duplicated shipping rates
+        )); // Work-around for Magento bug causing duplicated shipping rates
 
         $convertedQuote = [
             'order_data' => [

--- a/view/frontend/web/js/view/express-pay.js
+++ b/view/frontend/web/js/view/express-pay.js
@@ -54,9 +54,8 @@ define([
 
                                 try {
                                     await expressPay.updateOrder(data['orderID']);
-                                    return actions.resolve();
                                 } catch (e) {
-                                    return action.reject(data.errors.ADDRESS_ERROR);
+                                    return actions.reject(data.errors.ADDRESS_ERROR);
                                 }
                             },
                         }).render(element);

--- a/view/frontend/web/js/view/express-pay.js
+++ b/view/frontend/web/js/view/express-pay.js
@@ -48,7 +48,17 @@ define([
                                 } else {
                                     messageList.addErrorMessage({ message: $t('An error occurred while processing your payment. Please try again.') });
                                 }
-                            }
+                            },
+                            async onShippingAddressChange(data, actions) {
+                                expressPay.updateQuoteShippingAddress(data['shippingAddress']);
+
+                                try {
+                                    await expressPay.updateOrder(data['orderID']);
+                                    return actions.resolve();
+                                } catch (e) {
+                                    return action.reject(data.errors.ADDRESS_ERROR);
+                                }
+                            },
                         }).render(element);
                     }
                 });


### PR DESCRIPTION
- Frontend logic to implement the PPCP express pay callback for `onShippingAddressChange`.
- Updates the `Update` service to reflect changes to the checkout endpoint where Gateway Id and local are now required
- Fixes non-sequential array issue in QuoteConverter which was causing 'shipping_options' to be json encoded as an object instead of an array