### PR TITLE
Fix PPCP Fastlane is destroying SDK components in case Fastlane is loaded after.

### DIFF
--- a/view/frontend/web/js/action/show-fastlane-shipping-address-form.js
+++ b/view/frontend/web/js/action/show-fastlane-shipping-address-form.js
@@ -1,9 +1,9 @@
 define(
     [
-        'Bold_CheckoutPaymentBooster/js/model/fastlane',
+        'Bold_CheckoutPaymentBooster/js/model/spi',
         'Bold_CheckoutPaymentBooster/js/action/set-quote-shipping-address'
     ], function (
-        fastlane,
+        spi,
         setQuoteShippingAddressAction
     ) {
         'use strict';
@@ -21,7 +21,7 @@ define(
              * @private
              */
             const showFastlaneAddressModal = async function () {
-                const fastlaneInstance = await fastlane.getFastlaneInstance();
+                const fastlaneInstance = await spi.getFastlaneInstance();
                 if (!fastlaneInstance) {
                     return {selectionChanged: false, selectedAddress: {}};
                 }

--- a/view/frontend/web/js/model/fastlane.js
+++ b/view/frontend/web/js/model/fastlane.js
@@ -1,9 +1,8 @@
 define([
     'ko',
-    'Bold_CheckoutPaymentBooster/js/model/spi',
+    'prototype'
 ], function (
     ko,
-    spi,
 ) {
     'use strict';
 
@@ -42,7 +41,7 @@ define([
          *
          * @return {Promise<{profile: {showShippingAddressSelector: function}, identity: {lookupCustomerByEmail: function, triggerAuthenticationFlow: function}, FastlanePaymentComponent: function}>}
          */
-        getFastlaneInstance: async function () {
+        getFastlaneInstance: async function (boldPaymentsInstance) {
             if (!this.isAvailable()) {
                 return null;
             }
@@ -62,7 +61,6 @@ define([
             window.boldFastlaneInstanceCreateInProgress = true;
             try {
                 if (!this.gatewayData) {
-                    const boldPaymentsInstance = await spi.getPaymentsClient();
                     boldPaymentsInstance.state = {options: {fastlane: this.isAvailable()}};
                     this.gatewayData = (await boldPaymentsInstance.getFastlaneClientInit())[window.checkoutConfig.bold.gatewayId] || null;
                 }

--- a/view/frontend/web/js/model/spi.js
+++ b/view/frontend/web/js/model/spi.js
@@ -3,12 +3,14 @@ define([
     'Bold_CheckoutPaymentBooster/js/action/create-wallet-pay-order-action',
     'Bold_CheckoutPaymentBooster/js/action/payment-sca-action',
     'Magento_Checkout/js/model/quote',
+    'Bold_CheckoutPaymentBooster/js/model/fastlane',
     'prototype'
 ], function (
     registry,
     createOrderAction,
     paymentScaAction,
-    quote
+    quote,
+    fastlane
 ) {
     'use strict';
 
@@ -100,9 +102,18 @@ define([
                     }.bind(this)
                 }
             };
-            this.paymentsInstance = new window.bold.Payments(initialData);
+            const paymentInstance = new window.bold.Payments(initialData);
+            this.fastlaneInstance = await fastlane.getFastlaneInstance(paymentInstance);
+            this.paymentsInstance = paymentInstance;
             this.createPaymentsInstanceInProgress = false;
             return this.paymentsInstance;
+        },
+        getFastlaneInstance: async function () {
+            if (this.fastlaneInstance) {
+                return this.fastlaneInstance;
+            }
+            await this.getPaymentsClient();
+            return this.fastlaneInstance;
         },
     };
 });

--- a/view/frontend/web/js/view/form/element/email/fastlane-mixin.js
+++ b/view/frontend/web/js/view/form/element/email/fastlane-mixin.js
@@ -1,5 +1,6 @@
 define(
     [
+        'Bold_CheckoutPaymentBooster/js/model/spi',
         'Bold_CheckoutPaymentBooster/js/model/fastlane',
         'Bold_CheckoutPaymentBooster/js/view/shipping-address/list',
         'Magento_Customer/js/model/address-list',
@@ -12,6 +13,7 @@ define(
         'Bold_CheckoutPaymentBooster/js/action/reset-shipping-address',
         'Magento_Checkout/js/model/quote'
     ], function (
+        spi,
         fastlane,
         addressList,
         customerAddressList,
@@ -44,7 +46,7 @@ define(
                             return;
                         }
                         this.template = 'Bold_CheckoutPaymentBooster/form/element/email';
-                        fastlane.getFastlaneInstance().then((fastlaneInstance) => {
+                        spi.getFastlaneInstance().then((fastlaneInstance) => {
                             if (!fastlaneInstance) {
                                 return;
                             }
@@ -85,7 +87,7 @@ define(
                     lookupEmail: async function () {
                         try {
                             fullScreenLoader.startLoader();
-                            const fastlaneInstance = await fastlane.getFastlaneInstance();
+                            const fastlaneInstance = await spi.getFastlaneInstance();
                             if (!fastlaneInstance) {
                                 return;
                             }

--- a/view/frontend/web/js/view/payment/method-renderer/bold-fastlane.js
+++ b/view/frontend/web/js/view/payment/method-renderer/bold-fastlane.js
@@ -5,6 +5,7 @@ define(
         'Magento_Checkout/js/action/select-payment-method',
         'Magento_Checkout/js/action/select-billing-address',
         'Bold_CheckoutPaymentBooster/js/model/bold-frontend-client',
+        'Bold_CheckoutPaymentBooster/js/model/spi',
         'Bold_CheckoutPaymentBooster/js/model/fastlane',
         'Bold_CheckoutPaymentBooster/js/action/convert-fastlane-address',
         'Magento_Checkout/js/model/quote',
@@ -21,6 +22,7 @@ define(
         selectPaymentMethodAction,
         selectBillingAddressAction,
         boldFrontendClient,
+        spi,
         fastlane,
         convertFastlaneAddressAction,
         quote,
@@ -100,7 +102,7 @@ define(
              */
             renderCardComponent: async function () {
                 try {
-                    const fastlaneInstance = await fastlane.getFastlaneInstance();
+                    const fastlaneInstance = await spi.getFastlaneInstance();
                     if (!fastlaneInstance) {
                         this.isPlaceOrderActionAllowed(false);
                         this.isVisible(false);

--- a/view/frontend/web/js/view/shipping-address/list.js
+++ b/view/frontend/web/js/view/shipping-address/list.js
@@ -4,6 +4,7 @@ define(
         'Magento_Checkout/js/view/shipping-address/list',
         'Magento_Customer/js/model/address-list',
         'Bold_CheckoutPaymentBooster/js/action/show-shipping-address-form',
+        'Bold_CheckoutPaymentBooster/js/model/spi',
         'Bold_CheckoutPaymentBooster/js/model/fastlane',
         'Magento_Checkout/js/model/quote'
     ],
@@ -12,6 +13,7 @@ define(
         shippingAddressList,
         customerAddressList,
         showShippingAddressFormAction,
+        spi,
         fastlane,
         quote
     ) {
@@ -61,7 +63,7 @@ define(
                     return;
                 }
                 this.visible(true);
-                fastlane.getFastlaneInstance().then((fastlaneInstance) => {
+                spi.getFastlaneInstance().then((fastlaneInstance) => {
                     if (!fastlaneInstance) {
                         return;
                     }


### PR DESCRIPTION
Workaround to make Fastlane Instance loaded before Payments SDK starts rendering it's components. Should be properly fixed on payments SDK side.