### PR TITLE
[CHK-5787] Add onRequireOrderData callback

### DIFF
--- a/view/frontend/web/js/action/convert-magento-address.js
+++ b/view/frontend/web/js/action/convert-magento-address.js
@@ -1,0 +1,42 @@
+define(
+    [
+        'Magento_Checkout/js/model/new-customer-address',
+        'Magento_Customer/js/customer-data',
+        'checkoutData'
+    ], function (
+        NewCustomerAddressModel,
+        customerData,
+        checkoutData
+    ) {
+        'use strict';
+        /**
+         * Convert Magento address to Bold address.
+         *
+         * @param {Object} boldAddress
+         * @return {Object}
+         */
+        return function (magentoAddress) {
+            let street1 = '';
+            let street2 = '';
+            if (magentoAddress.street && magentoAddress.street[0]) {
+                street1 = magentoAddress.street[0];
+            }
+            if (magentoAddress.street && magentoAddress.street[1]) {
+                street2 = magentoAddress.street[1];
+            }
+
+            return {
+                email: customerData.email ?? checkoutData.getValidatedEmailValue(),
+                country_code: magentoAddress.countryId,
+                city: magentoAddress.city ?? '',
+                first_name: magentoAddress.firstname ?? '',
+                last_name: magentoAddress.lastname ?? '',
+                phone_number: magentoAddress.telephone ?? '',
+                postal_code: magentoAddress.postcode,
+                province: magentoAddress.region,
+                province_code: magentoAddress.regionCode,
+                address_line_1: street1,
+                address_line_2: street2
+            };
+        };
+    });

--- a/view/frontend/web/js/model/spi.js
+++ b/view/frontend/web/js/model/spi.js
@@ -129,34 +129,34 @@ define([
                     'onRequireOrderData' : async function (requirements) {
                         const payload = {};
 
-                        for (const rq of requirements) {
-                            switch (rq) {
+                        for (const requirement of requirements) {
+                            switch (requirement) {
                                 case 'customer':
                                     let billingAddress = quote.billingAddress();
                                     const email = checkoutData.getValidatedEmailValue()
                                         ? checkoutData.getValidatedEmailValue()
                                         : window.checkoutConfig.customerData.email;
 
-                                    payload[rq] = {
+                                    payload[requirement] = {
                                         first_name: billingAddress.firstname,
                                         last_name: billingAddress.lastname,
                                         email_address: email,
                                     };
                                     break;
                                 case 'items':
-                                    payload[rq] = quote.getItems().map(item => ({
+                                    payload[requirement] = quote.getItems().map(item => ({
                                         amount: parseInt(parseFloat(item.base_price) * 100),
                                         label: item.name
                                     }));
                                     break;
                                 case 'billing_address':
-                                    payload[rq] = convertMagentoAddress(quote.billingAddress());
+                                    payload[requirement] = convertMagentoAddress(quote.billingAddress());
                                     break;
                                 case 'shipping_address':
-                                    payload[rq] = convertMagentoAddress(quote.shippingAddress());
+                                    payload[requirement] = convertMagentoAddress(quote.shippingAddress());
                                     break;
                                 case 'shipping_options':
-                                    payload[rq] = shippingService.getShippingRates().map(option => ({
+                                    payload[requirement] = shippingService.getShippingRates().map(option => ({
                                         label: `${option.carrier_title} - ${option.method_title}`,
                                         amount: option.amount,
                                         id: `${option.carrier_code}_${option.method_code}`
@@ -164,7 +164,7 @@ define([
                                     break;
                                 case 'totals':
                                     const totals = quote.getTotals();
-                                    payload[rq] = {
+                                    payload[requirement] = {
                                         order_total: totals()['grand_total'],
                                         order_balance: totals()['grand_total'],
                                         shipping_total: totals()['shipping_amount'],


### PR DESCRIPTION
Adds the `onRequireOrderData` callback. This resolves the issue of the missing PayPal messaging when it was enabled in the Bold Checkout admin.

<img width="859" alt="image" src="https://github.com/user-attachments/assets/3be54486-eb2d-490e-a4ef-bb3fb2eda3d1">
