### PR TITLE
[CHK-5961] - Use renderPayments on payment step

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "license": [
     "MIT"
   ],
-  "version": "2.0.0",
+  "version": "2.1.0",
   "require": {
     "magento/framework": ">=102.0.1 <103.0.8",
     "magento/module-checkout": ">=100.3.1 <100.4.8",

--- a/view/frontend/web/js/view/payment/method-renderer/bold-spi.js
+++ b/view/frontend/web/js/view/payment/method-renderer/bold-spi.js
@@ -97,8 +97,13 @@ define([
         renderPayments: async function () {
             const paymentsInstance = await spi.getPaymentsClient();
             const boldPaymentsForm = document.getElementById('SPI');
-            if (fastlane.isAvailable()) {
-                await paymentsInstance.renderWalletPayments('SPI');
+            const isFastlaneAvailable = fastlane.isAvailable();
+            if (isFastlaneAvailable) {
+                const paymentOptions = {
+                    fastlane: isFastlaneAvailable,
+                    shouldRenderSpiFrame: false
+                };
+                paymentsInstance.renderPayments('SPI', paymentOptions);
                 this.isBillingAddressRequired(false);
                 this.isPlaceOrderButtonVisible(false);
                 this.isSpiLoading(false);


### PR DESCRIPTION
On the payment step of checkout render wallet pay buttons using `renderPayments` instead of `renderWalletPayments`. This ensures the shipping strategy is set to `fixed`. 