### PR TITLE
Fix broken SPI placeOrder logic

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/bold-spi.js
+++ b/view/frontend/web/js/view/payment/method-renderer/bold-spi.js
@@ -126,16 +126,11 @@ define([
                 return;
             }
 
-            const containerId = 'SPI';
-            const observer = new MutationObserver(async () => {
-                if (document.getElementById(containerId)) {
-                    observer.disconnect();
-                    window.bold.paymentsInstance.renderPayments(containerId);
+            this.tokenize()
+            this.paymentId.subscribe((id) => {
+                if (id != null) {
+                    callback(data, event);
                 }
-            });
-            observer.observe(document.documentElement, {
-                childList: true,
-                subtree: true
             });
         },
 


### PR DESCRIPTION
The placeOrder logic for the SPI frame got broken during development of the express-pay feature. 

Reverting the previous code for this function to fix it. 