### PR TITLE
Add onErrorPaymentOrder callback

### DIFF
--- a/view/frontend/web/js/model/spi.js
+++ b/view/frontend/web/js/model/spi.js
@@ -8,6 +8,7 @@ define([
     'Bold_CheckoutPaymentBooster/js/model/spi/callbacks/on-require-order-data-callback',
     'Bold_CheckoutPaymentBooster/js/model/spi/callbacks/on-approve-payment-order-callback',
     'Bold_CheckoutPaymentBooster/js/model/spi/callbacks/on-sca-payment-order-callback',
+    'Magento_Ui/js/model/messageList'
 ], function (
     quote,
     fullScreenLoader,
@@ -17,7 +18,8 @@ define([
     onUpdatePaymentOrderCallback,
     onRequireOrderDataCallback,
     onApprovePaymentOrderCallback,
-    onScaPaymentOrderCallback
+    onScaPaymentOrderCallback,
+    messageList
 ) {
     'use strict';
 
@@ -112,6 +114,10 @@ define([
                             fullScreenLoader.stopLoader();
                             throw e;
                         }
+                    },
+                    'onErrorPaymentOrder': function (errors) {
+                        console.error('An unexpected PayPal error occurred', errors);
+                        messageList.addErrorMessage({message: 'Warning: An unexpected error occurred. Please try again.'});
                     },
                 }
             };


### PR DESCRIPTION
Adds the `onErrorPaymentOrder` callback. This will show a generic error message on the checkout page and console.error the parameter (if any) that is passed to the callback

<img width="829" alt="image" src="https://github.com/user-attachments/assets/88484346-9214-4cf4-ad83-2b0df0d35c58">
