### PR TITLE
Fix Braintree button styling

### DIFF
--- a/view/frontend/web/css/source/_module.less
+++ b/view/frontend/web/css/source/_module.less
@@ -6,6 +6,14 @@
   padding-top: 15px;
 }
 
+.braintree-express-payments span {
+  margin: 0;
+}
+
+.braintree-express-payments > div > div {
+  width: 100%;
+}
+
 #PIGI.payment__iframe--display-sca {
   position: fixed;
   top: 0;


### PR DESCRIPTION
Resolves [CHK-6278](https://boldapps.atlassian.net/browse/CHK-6278)

Magento has a core dependency on a PayPal Braintree module which is interfering with the styling of the PayPal buttons coming from the SDK. 

Given that we cannot remove the styles from this external module this PR fixes the styles within our module. 

[CHK-6278]: https://boldapps.atlassian.net/browse/CHK-6278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<img width="858" alt="Screenshot 2024-11-14 at 12 12 07 PM" src="https://github.com/user-attachments/assets/2559e01b-1d53-41f3-93c7-dfc6899503dc">
