### PR TITLE
[CHK-6365] Use Quote Shipping Method Before Defaulting to First Available

### DIFF
--- a/view/frontend/web/js/action/express-pay/update-quote-shipping-method-action.js
+++ b/view/frontend/web/js/action/express-pay/update-quote-shipping-method-action.js
@@ -21,6 +21,7 @@ define(
          */
         return async function (shippingMethod = null) {
             let newMethod = null;
+            shippingMethod = shippingMethod ?? quote.shippingMethod();
             if (shippingMethod !== null) {
                 let availableMethods = shippingService.getShippingRates().filter((method) => {
                     let methodId = `${method.carrier_code}_${method.method_code}`;


### PR DESCRIPTION
Bold Booster orders were selecting first listed shipping method, even when one is already selected. Now it is possible to complete an order with a different shipping method than the first listed.