### PR TITLE
[CHK-5203] Remove Void Return Type from Log Request

### DIFF
--- a/Model/Http/Client/RequestsLogger.php
+++ b/Model/Http/Client/RequestsLogger.php
@@ -63,7 +63,7 @@ class RequestsLogger
      * @param array|null $data
      * @return void
      */
-    public function logRequest(int $websiteId, string $url, string $method, ?array $data = null): void
+    public function logRequest(int $websiteId, string $url, string $method, ?array $data = null)
     {
         if (!$this->config->getLogIsEnabled($websiteId)) {
             return;
@@ -84,7 +84,7 @@ class RequestsLogger
      * @param ClientInterface $client
      * @return void
      */
-    public function logResponse(int $websiteId, ClientInterface $client): void
+    public function logResponse(int $websiteId, ClientInterface $client)
     {
         if (!$this->config->getLogIsEnabled($websiteId)) {
             return;


### PR DESCRIPTION
Log Request was causing error on Magento version 2.4.3 when running `setup:upgrade` for not matching the declaration. 
Removing the return type so the declarations match.