### PR TITLE
CHK-6756: Hide loading spinner if Magento order validation fails

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/bold-spi.js
+++ b/view/frontend/web/js/view/payment/method-renderer/bold-spi.js
@@ -120,13 +120,22 @@ define([
 
         /** @inheritdoc */
         placeOrder: function (data, event) {
-            fullscreenLoader.startLoader();
             const placeMagentoOrder = this._super.bind(this);
             if (this.paymentId()) {
                 return placeMagentoOrder(data, event);
             }
             this.tokenize();
             return false;
+        },
+
+        /**
+         * Show full-screen loader and process the order.
+         *
+         * @return boolean
+         */
+        placeOrderClick: function (data, event) {
+            fullscreenLoader.startLoader();
+            return this.placeOrder(data, event);
         },
 
         /**
@@ -212,7 +221,12 @@ define([
                             return;
                         }
                         this.paymentId(paymentId);
-                        this.placeOrder({}, jQuery.Event());
+
+                        const placeOrderSuccess = this.placeOrder({}, jQuery.Event());
+                        if (!placeOrderSuccess) {
+                            fullscreenLoader.stopLoader();
+                        }
+
                         break;
                     case 'EVENT_SPI_TOKENIZE_FAILED':
                         this.paymentId(null);

--- a/view/frontend/web/template/payment/spi.html
+++ b/view/frontend/web/template/payment/spi.html
@@ -36,7 +36,7 @@
                     <button class="action primary checkout"
                             type="submit"
                             data-bind="
-                            click: placeOrder,
+                            click: placeOrderClick,
                             attr: {title: $t('Place Order')},
                             css: {disabled: isSpiLoading()},
                             enable: (getCode() == isChecked())


### PR DESCRIPTION
If `placeOrder` returns `false`, this means that the Magento order validation failed so we call `stopLoader` to hide the loading spinner to allow the user to correct the error. This alone didn't work because the `placeOrder` function is called twice and two loaders get added to the page. I made a change to only call `startLoader` when the Place Order button is clicked. 