### PR TITLE
[CHK-4370] Enable GPAY PPCP Express Checkout

### DIFF
--- a/view/frontend/web/js/action/express-pay/update-quote-shipping-method-action.js
+++ b/view/frontend/web/js/action/express-pay/update-quote-shipping-method-action.js
@@ -20,23 +20,26 @@ define(
          * @return void
          */
         return async function (shippingMethod = null) {
-            let newMethod = null;
+            let newMethod;
+            let ms = 100;
+            let carry = 100;
+            while (shippingService.isLoading() && ms < 5000) {
+                // max total timeout is 8000ms
+                await new Promise(resolve => setTimeout(resolve, ms));
+                carry = ms + carry;
+                ms = carry - ms;
+            }
             shippingMethod = shippingMethod ?? quote.shippingMethod();
             if (shippingMethod !== null) {
-                let availableMethods = shippingService.getShippingRates().filter((method) => {
+                newMethod = shippingService.getShippingRates().filter((method) => {
                     let methodId = `${method.carrier_code}_${method.method_code}`;
                     methodId = methodId.replace(/\s/g, '');
-                    return methodId === shippingMethod['id'] || methodId === shippingMethod['identifier'];
-                });
-                if (availableMethods.length > 0) {
-                    newMethod = availableMethods[0];
-                }
-            } else {
-                newMethod = shippingService.getShippingRates().first();
+                    return methodId === shippingMethod['id'] 
+                        || methodId === shippingMethod['identifier'] 
+                        || methodId === `${shippingMethod.carrier_code}_${shippingMethod.method_code}`;
+                }).first();
             }
-            if (newMethod !== null) {
-                selectShippingMethodAction(newMethod);
-            }
+            selectShippingMethodAction(newMethod ?? shippingService.getShippingRates().first());
             if (quote.guestEmail === null) {
                 quote.guestEmail = 'test@test.com';
             }

--- a/view/frontend/web/js/action/express-pay/update-quote-shipping-method-action.js
+++ b/view/frontend/web/js/action/express-pay/update-quote-shipping-method-action.js
@@ -21,13 +21,13 @@ define(
          */
         return async function (shippingMethod = null) {
             let newMethod;
-            let ms = 100;
+            let timeoutMS = 100;
             let carry = 100;
-            while (shippingService.isLoading() && ms < 5000) {
+            while (shippingService.isLoading() && timeoutMS < 5000) {
                 // max total timeout is 8000ms
-                await new Promise(resolve => setTimeout(resolve, ms));
-                carry = ms + carry;
-                ms = carry - ms;
+                await new Promise(resolve => setTimeout(resolve, timeoutMS));
+                carry = timeoutMS + carry;
+                timeoutMS = carry - timeoutMS;
             }
             shippingMethod = shippingMethod ?? quote.shippingMethod();
             if (shippingMethod !== null) {


### PR DESCRIPTION
Update the `updateQuoteShippingMethodAction` to handle PPCP Gpay Express pay checkout

Return the first from the filtered available shipping rates because only one should match. Previously we checked the length and returned the first index. With the first function we will either return the matching shipping method or `undefined`
Removed the null check on `newMethod` for setting a default shipping method. Made use of the null coalescing to cover for `newMethod` to be `null` or `undefined` and put it directly in the set shipping param.