### PR TITLE
EPS-170: Fix inconsistent font style

### DIFF
--- a/view/frontend/web/css/source/_module.less
+++ b/view/frontend/web/css/source/_module.less
@@ -41,3 +41,9 @@
 #express-pay-buttons {
     min-height: 60px;
 }
+
+.ToggleField__Text {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    font-size: 100%;
+    color: #1a1a1a;
+}


### PR DESCRIPTION
- The font style for Wallet pays was override by font in M2 module, added custom css to make sure the font style consistent

<img width="870" alt="Screenshot 2024-12-05 at 9 52 05 AM" src="https://github.com/user-attachments/assets/c0721c38-3ec1-4f21-a1d1-ec26742a2a5f">
