### PR TITLE
[CHK-6462] Enable Google Pay Button on Payment Step

### DIFF
--- a/view/frontend/web/js/action/express-pay/update-quote-ppcp-action.js
+++ b/view/frontend/web/js/action/express-pay/update-quote-ppcp-action.js
@@ -33,7 +33,7 @@ define(
             try {
                 order = await getExpressPayOrderAction(
                     paymentApprovalData.gateway_id,
-                    paymentApprovalData.payment_data.order_id
+                    paymentApprovalData.payment_data.order_id ?? paymentApprovalData.order_id
                 );
             } catch (error) {
                 console.error('Could not retrieve Express Pay order.', error);

--- a/view/frontend/web/js/model/spi/callbacks/on-approve-payment-order-callback.js
+++ b/view/frontend/web/js/model/spi/callbacks/on-approve-payment-order-callback.js
@@ -44,7 +44,7 @@ define(
 
             if (paymentType === 'ppcp' || isWalletPayment) {
                 paymentMethodData['additional_data'] = {
-                    order_id: paymentApprovalData?.payment_data.order_id
+                    order_id: paymentApprovalData?.payment_data.order_id ?? paymentApprovalData.order_id
                 };
             }
 

--- a/view/frontend/web/js/view/payment/method-renderer/bold-spi.js
+++ b/view/frontend/web/js/view/payment/method-renderer/bold-spi.js
@@ -101,11 +101,11 @@ define([
             this.isSpiLoading(false);
 
             if (isFastlaneAvailable) {
-                const paymentOptions = {
+                const fastlaneOptions = {
                     fastlane: isFastlaneAvailable,
                     shouldRenderSpiFrame: false
                 };
-                paymentsInstance.renderPayments('SPI', paymentOptions);
+                paymentsInstance.renderPayments('SPI', fastlaneOptions);
                 this.isBillingAddressRequired(false);
                 this.isPlaceOrderButtonVisible(false);
                 if (boldPaymentsForm.getHTML().trim() === '') {
@@ -115,7 +115,13 @@ define([
             }
             this.isBillingAddressRequired(true);
             this.isPlaceOrderButtonVisible(true);
-            paymentsInstance.renderPayments('SPI');
+            const paymentOptions = {
+                fastlane: false,
+                shouldRenderSpiFrame: true,
+                shouldRenderPaypalButton: true,
+                shouldRenderAppleGoogleButtons: true,
+            }
+            paymentsInstance.renderPayments('SPI', paymentOptions);
         },
 
         /** @inheritdoc */


### PR DESCRIPTION
Add payment options to render google pay button with the SPI iframe.

- Renamed the fastlane payment options to avoid confusion with the non fastlane payment options
- Added backup order id path from the payment data because google do be like that sometimes

Resolves [CHK-6462](https://boldapps.atlassian.net/browse/CHK-6462)

[CHK-6462]: https://boldapps.atlassian.net/browse/CHK-6462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ