### PR TITLE
[CHK-6869] Remove Prototype Import to Prevent JS Dump

### DIFF
--- a/view/frontend/web/js/action/express-pay/update-quote-shipping-method-action.js
+++ b/view/frontend/web/js/action/express-pay/update-quote-shipping-method-action.js
@@ -37,7 +37,7 @@ define(
                     return methodId === shippingMethod['id'] 
                         || methodId === shippingMethod['identifier'] 
                         || methodId === `${shippingMethod.carrier_code}_${shippingMethod.method_code}`;
-                }).first();
+                })[0];
             }
             selectShippingMethodAction(newMethod ?? shippingService.getShippingRates().first());
             if (quote.guestEmail === null) {

--- a/view/frontend/web/js/model/fastlane.js
+++ b/view/frontend/web/js/model/fastlane.js
@@ -1,7 +1,6 @@
 define([
     'ko',
-    'Bold_CheckoutPaymentBooster/js/action/general/load-script-action',
-    'prototype'
+    'Bold_CheckoutPaymentBooster/js/action/general/load-script-action'
 ], function (
     ko,
     loadScriptAction,

--- a/view/frontend/web/js/model/fastlane.js
+++ b/view/frontend/web/js/model/fastlane.js
@@ -160,16 +160,17 @@ define([
          * @param {{}} gatewayData
          */
         addAuthorizationAttributesToPayPalScript: function (gatewayData) {
-            Element.prototype.appendChild = Element.prototype.appendChild.wrap(
-                function (appendChild, element) {
-                    if (element.attributes && element.attributes['data-requiremodule']?.value === 'bold_paypal_fastlane') {
-                        // Require.js < 2.1.19 is not calling onNodeCreated config callback, so we need to set the client token manually.
-                        element.setAttribute('data-sdk-client-token', gatewayData.client_token);
-                        element.setAttribute('data-client-metadata-id', window.checkoutConfig.bold.publicOrderId);
-                    }
-                    return appendChild(element);
+            var defaultLoad = require.load;
+            require.load = function (context, moduleName, url) {
+                var element = defaultLoad(context, moduleName, url);
+                if (element.attributes && element.attributes['data-requiremodule']?.value === 'bold_paypal_fastlane') {
+                    // Require.js < 2.1.19 is not calling onNodeCreated config callback, so we need to set the client token manually.
+                    element.setAttribute('data-sdk-client-token', gatewayData.client_token);
+                    element.setAttribute('data-client-metadata-id', window.checkoutConfig.bold.publicOrderId);
                 }
-            );
+
+                return element;
+            };
         },
         /**
          * Set Fastlane locale.


### PR DESCRIPTION
On older M2 versions, like 2.4.5, if you define prototype the billing address details can spit out javascript as text.
![image](https://github.com/user-attachments/assets/3e34cb7f-3131-4f3e-b8dc-4b70d13a228b)


Removed the import from `fastlane.js` and changed the update shipping method callback function to use `[0]` instead of `.first()` when filtering for the currently selected shipping method.
Replaced the `prototype.wrap()` called on `appendChild` with overriding require load to add credentials for the fast lane script

Fixes [CHK-6869](https://boldapps.atlassian.net/browse/CHK-6869)

[CHK-6869]: https://boldapps.atlassian.net/browse/CHK-6869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ