### PR TITLE
[CHK-4614] Adobe Commerce: As a brand using Payment Booster, I want to offer branded PPCP buttons on my product pages

### DIFF
--- a/Api/Quote/GetQuoteInterface.php
+++ b/Api/Quote/GetQuoteInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\CheckoutPaymentBooster\Api\Quote;
+
+/**
+ * Hydrate Bold order from Magento quote.
+ */
+interface GetQuoteInterface
+{
+    /**
+     * Gets Current Session Quote ID
+     *
+     * @return string
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function getQuoteId();
+}

--- a/Model/InitOrderFromQuote.php
+++ b/Model/InitOrderFromQuote.php
@@ -75,7 +75,7 @@ class InitOrderFromQuote
             'cart_id' => $quote->getId() ?? '',
         ];
         $orderData = $this->client->post(
-            (int)$quote->getStore()->getWebsiteId(),
+            (int)$websiteId,
             self::INIT_SIMPLE_ORDER_URI,
             $body
         );

--- a/Observer/Product/ExpressPayBeforeAddToCartObserver.php
+++ b/Observer/Product/ExpressPayBeforeAddToCartObserver.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\CheckoutPaymentBooster\Observer\Product;
+
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Checkout\Model\Session;
+use Magento\Quote\Api\CartRepositoryInterface;
+
+/**
+ * Observer for `controller_action_predispatch_checkout_cart_add` event
+ *
+ * @see \Magento\Framework\App\FrontController::dispatchPreDispatchEvents
+ * @see \Magento\Checkout\Controller\Cart\Add::execute
+ */
+class ExpressPayBeforeAddToCartObserver implements ObserverInterface
+{
+    /**
+     * @var Session
+     */
+    protected $checkoutSession;
+
+    /**
+     * @var CartRepositoryInterface
+     */
+    protected $cartRepository;
+
+    public function __construct(Session $checkoutSession, CartRepositoryInterface $cartRepository)
+    {
+        $this->checkoutSession = $checkoutSession;
+        $this->cartRepository = $cartRepository;
+    }
+
+    /**
+     * Clear the cart before checking out with Express Pay from the product detail page
+     *
+     * @param Observer $observer
+     * @return void
+     */
+    public function execute(Observer $observer): void
+    {
+        $request = $observer->getEvent()->getRequest();
+        $isExpressPayOrder = $request->getParam('source') === 'expresspay';
+
+        $quote = $this->checkoutSession->getQuote();
+
+        if (!$isExpressPayOrder) {
+            return;
+        }
+        $this->checkoutSession->setCheckoutState(true);
+        $quote->removeAllItems();
+        $quote->setTotalsCollectedFlag(false);
+        $this->checkoutSession->clearQuote();
+
+        $this->cartRepository->save($quote);
+        $this->checkoutSession->setQuoteId($quote->getId());
+    }
+}

--- a/Observer/ShortcutButtons/AddExpressPayButtonsObserver.php
+++ b/Observer/ShortcutButtons/AddExpressPayButtonsObserver.php
@@ -6,6 +6,7 @@ namespace Bold\CheckoutPaymentBooster\Observer\ShortcutButtons;
 
 use Bold\CheckoutPaymentBooster\Block\ShortcutButtons\ExpressPayShortcutButtons;
 use Bold\CheckoutPaymentBooster\ViewModel\ExpressPayFactory;
+use Bold\CheckoutPaymentBooster\UI\PaymentBoosterConfigProvider;
 use Magento\Catalog\Block\ShortcutButtons;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Event\Observer;
@@ -32,14 +33,21 @@ class AddExpressPayButtonsObserver implements ObserverInterface
         $event = $observer->getEvent();
         /** @var ShortcutButtons $container */
         $container = $event->getData('container');
+
+        $layout = $container->getLayout();
+
+        if ($layout->getBlock(ExpressPayShortcutButtons::BLOCK_ALIAS) !== false) {
+            return;
+        }
+
         /** @var ExpressPayShortcutButtons $expressPayShortcutButtons */
-        $expressPayShortcutButtons = $container->getLayout()->createBlock(
+        $expressPayShortcutButtons = $layout->createBlock(
             ExpressPayShortcutButtons::class,
             ExpressPayShortcutButtons::BLOCK_ALIAS,
             [
                 'data' => [
                     'express_pay_view_model' => $this->expressPayFactory->create(),
-                    'render_page_source' => 'mini-cart'
+                    'render_page_source' => PaymentBoosterConfigProvider::PAGE_SOURCE_MINICART
                 ]
             ]
         );

--- a/Service/Quote/GetQuote.php
+++ b/Service/Quote/GetQuote.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\CheckoutPaymentBooster\Service\Quote;
+
+use Bold\CheckoutPaymentBooster\Api\Quote\GetQuoteInterface;
+use Magento\Checkout\Model\Session;
+use Magento\Quote\Model\QuoteIdToMaskedQuoteIdInterface;
+
+/**
+ * Get Current Quote ID from Magento quote.
+ */
+class GetQuote implements GetQuoteInterface
+{
+    /**
+     * @var Session
+     */
+    private $checkoutSession;
+
+    /**
+     * @var QuoteIdToMaskedQuoteId
+     */
+    private $quoteIdToMaskedQuoteId;
+
+    public function __construct(
+        Session $checkoutSession,
+        QuoteIdToMaskedQuoteIdInterface $quoteIdToMaskedQuoteId
+    ) {
+        $this->checkoutSession = $checkoutSession;
+        $this->quoteIdToMaskedQuoteId = $quoteIdToMaskedQuoteId;
+    }
+
+    /**
+     * Gets Current Session Quote ID
+     *
+     * @return string
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function getQuoteId()
+    {
+        $quoteId = (int)$this->checkoutSession->getQuote()->getId();
+        $quoteIdMask = $this->quoteIdToMaskedQuoteId->execute($quoteId);
+
+        return $quoteIdMask;
+    }
+}

--- a/ViewModel/ExpressPay.php
+++ b/ViewModel/ExpressPay.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Bold\CheckoutPaymentBooster\ViewModel;
 
+use Magento\Framework\View\Element\Block\ArgumentInterface;
+use Bold\CheckoutPaymentBooster\Model\CheckoutData;
 use Bold\CheckoutPaymentBooster\Model\Config;
 use Magento\Checkout\Model\CompositeConfigProvider;
-use Magento\Checkout\Model\Session;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Bold\CheckoutPaymentBooster\UI\PaymentBoosterConfigProvider;
 use Magento\Framework\Serialize\SerializerInterface;
-use Magento\Framework\View\Element\Block\ArgumentInterface;
+use Magento\Checkout\Model\Session;
 use Magento\Store\Model\StoreManagerInterface;
 
 class ExpressPay implements ArgumentInterface
@@ -36,9 +38,21 @@ class ExpressPay implements ArgumentInterface
     private $storeManager;
 
     /**
+     * @var CheckoutData
+     */
+    private $checkoutData;
+
+    /**
      * @var Config
      */
     private $config;
+
+    /**
+     * @var PaymentBoosterConfigProvider
+     */
+    private $paymentBoosterConfigProvider;
+
+
 
     /**
      * @var mixed[]
@@ -50,13 +64,17 @@ class ExpressPay implements ArgumentInterface
         SerializerInterface $serializer,
         Session $checkoutSession,
         StoreManagerInterface $storeManager,
-        Config $config
+        CheckoutData $checkoutData,
+        Config $config,
+        PaymentBoosterConfigProvider $paymentBoosterConfigProvider
     ) {
         $this->configProvider = $configProvider;
         $this->serializer = $serializer;
         $this->checkoutSession = $checkoutSession;
         $this->storeManager = $storeManager;
+        $this->checkoutData = $checkoutData;
         $this->config = $config;
+        $this->paymentBoosterConfigProvider = $paymentBoosterConfigProvider;
     }
 
     /**
@@ -64,26 +82,57 @@ class ExpressPay implements ArgumentInterface
      */
     public function getJsLayout()
     {
-        $this->jsLayout['checkoutConfig'] = $this->configProvider->getConfig();
+        $quoteId = $this->checkoutSession->getQuote()->getId();
+        if ($quoteId !== null) {
+            $this->jsLayout['checkoutConfig'] = $this->configProvider->getConfig();
+        } else {
+            $this->checkoutData->initCheckoutData();
+            $this->jsLayout['checkoutConfig'] = $this->paymentBoosterConfigProvider->getConfigWithoutQuote();
+        }
+
         return $this->serializer->serialize($this->jsLayout);
     }
 
     /**
      * @return bool
-     * @throws NoSuchEntityException
      */
-    public function isCartWalletPayEnabled(): bool
+    public function isEnabled($pageSource = ''): bool
     {
-        $websiteId = (int) $this->storeManager->getStore()->getWebsiteId();
+        $hasActiveQuote = $this->hasActiveQuote();
+
+        switch ($pageSource) {
+            case PaymentBoosterConfigProvider::PAGE_SOURCE_CART:
+                $isEnabled = $this->isCartWalletPayEnabled() && $hasActiveQuote;
+                break;
+            case PaymentBoosterConfigProvider::PAGE_SOURCE_PRODUCT:
+                $isEnabled = $this->isProductWalletPayEnabled();
+                break;
+            case PaymentBoosterConfigProvider::PAGE_SOURCE_MINICART:
+                $isEnabled = $this->isCartWalletPayEnabled() && $hasActiveQuote;
+                break;
+            default:
+                $isEnabled = false;
+                break;
+        }
+
+        return $isEnabled;
+    }
+
+    /**
+     * @return bool
+     */
+    private function isCartWalletPayEnabled(): bool
+    {
+        $websiteId = (int)$this->storeManager->getStore()->getWebsiteId();
         return $this->config->isCartWalletPayEnabled($websiteId);
     }
 
     /**
-     * @param int $websiteId
      * @return bool
      */
-    public function isProductWalletPayEnabled(int $websiteId): bool
+    private function isProductWalletPayEnabled(): bool
     {
+        $websiteId = (int)$this->storeManager->getStore()->getWebsiteId();
         return $this->config->isProductWalletPayEnabled($websiteId);
     }
 
@@ -92,7 +141,7 @@ class ExpressPay implements ArgumentInterface
      * @throws NoSuchEntityException
      * @throws LocalizedException
      */
-    public function hasActiveQuote(): bool
+    private function hasActiveQuote(): bool
     {
         $quote = $this->checkoutSession->getQuote();
         return $quote->getId() !== null;

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -8,6 +8,7 @@
     <preference for="Bold\CheckoutPaymentBooster\Api\Order\UpdatePaymentsInterface" type="Bold\CheckoutPaymentBooster\Model\Order\UpdatePayments"/>
     <preference for="Bold\CheckoutPaymentBooster\Api\Data\Order\Payment\ResultInterface" type="Bold\CheckoutPaymentBooster\Model\Order\UpdatePayments\Result"/>
     <preference for="Bold\CheckoutPaymentBooster\Api\Data\Http\Client\ResultInterface" type="Bold\CheckoutPaymentBooster\Model\Http\Client\Result"/>
+    <preference for="Bold\CheckoutPaymentBooster\Api\Quote\GetQuoteInterface" type="Bold\CheckoutPaymentBooster\Service\Quote\GetQuote"/>
 
     <type name="Bold\CheckoutPaymentBooster\Model\Order\CheckPaymentMethod">
         <arguments>
@@ -122,12 +123,14 @@
     <type name="Bold\CheckoutPaymentBooster\Service\ExpressPay\Order\Create">
         <arguments>
             <argument name="httpClient" xsi:type="object">Bold\CheckoutPaymentBooster\Model\Http\BoldClient</argument>
+            <argument name="checkoutSession" xsi:type="object">Magento\Checkout\Model\Session\Proxy</argument>
         </arguments>
     </type>
 
     <type name="Bold\CheckoutPaymentBooster\Service\ExpressPay\Order\Update">
         <arguments>
             <argument name="httpClient" xsi:type="object">Bold\CheckoutPaymentBooster\Model\Http\BoldClient</argument>
+            <argument name="checkoutSession" xsi:type="object">Magento\Checkout\Model\Session\Proxy</argument>
         </arguments>
     </type>
 

--- a/etc/frontend/events.xml
+++ b/etc/frontend/events.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">  
+    <event name="controller_action_predispatch_checkout_cart_add">
+        <observer name="express_pay_before_add_to_cart" instance="Bold\CheckoutPaymentBooster\Observer\Product\ExpressPayBeforeAddToCartObserver"/>
+    </event>
     <event name="shortcut_buttons_container">
         <observer name="add_express_pay_buttons" instance="Bold\CheckoutPaymentBooster\Observer\ShortcutButtons\AddExpressPayButtonsObserver"/>
     </event>

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -63,5 +63,11 @@
             <!-- Authorization performed in service class -->
             <resource ref="anonymous" />
         </resources>
+    </route>    
+    <route url="/V1/cart/getQuoteId" method="GET">
+        <service class="Bold\CheckoutPaymentBooster\Api\Quote\GetQuoteInterface" method="getQuoteId"/>
+        <resources>
+            <resource ref="anonymous" />
+        </resources>
     </route>
 </routes>

--- a/view/frontend/layout/catalog_product_view.xml
+++ b/view/frontend/layout/catalog_product_view.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="product.info.addtocart">
+            <block name="express.pay" template="Bold_CheckoutPaymentBooster::express-pay.phtml">
+                <arguments>
+                    <argument name="express_pay_view_model" xsi:type="object">Bold\CheckoutPaymentBooster\ViewModel\ExpressPay</argument>
+                    <argument name="render_page_source" xsi:type="const">Bold\CheckoutPaymentBooster\UI\PaymentBoosterConfigProvider::PAGE_SOURCE_PRODUCT</argument>
+                </arguments>
+            </block>
+        </referenceBlock>
+        <referenceBlock name="product.info.addtocart.additional">
+            <block name="express.pay" template="Bold_CheckoutPaymentBooster::express-pay.phtml">
+                <arguments>
+                    <argument name="express_pay_view_model" xsi:type="object">Bold\CheckoutPaymentBooster\ViewModel\ExpressPay</argument>
+                    <argument name="render_page_source" xsi:type="const">Bold\CheckoutPaymentBooster\UI\PaymentBoosterConfigProvider::PAGE_SOURCE_PRODUCT</argument>
+                </arguments>
+            </block>
+        </referenceBlock>
+    </body>
+</page>

--- a/view/frontend/layout/catalog_product_view_type_bundle.xml
+++ b/view/frontend/layout/catalog_product_view_type_bundle.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0"?>
-
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <referenceContainer name="checkout.cart.methods">
-            <block name="express.pay" template="Bold_CheckoutPaymentBooster::express-pay.phtml" after="checkout.cart.methods.onepage.bottom">
+        <referenceBlock name="product.info.addtocart.bundle">
+            <block name="express.pay" template="Bold_CheckoutPaymentBooster::express-pay.phtml">
                 <arguments>
                     <argument name="express_pay_view_model" xsi:type="object">Bold\CheckoutPaymentBooster\ViewModel\ExpressPay</argument>
-                    <argument name="render_page_source" xsi:type="const">Bold\CheckoutPaymentBooster\UI\PaymentBoosterConfigProvider::PAGE_SOURCE_CART</argument>
+                    <argument name="render_page_source" xsi:type="const">Bold\CheckoutPaymentBooster\UI\PaymentBoosterConfigProvider::PAGE_SOURCE_PRODUCT</argument>
                 </arguments>
             </block>
-        </referenceContainer>
+        </referenceBlock>
     </body>
 </page>

--- a/view/frontend/templates/express-pay.phtml
+++ b/view/frontend/templates/express-pay.phtml
@@ -9,10 +9,10 @@ use Bold\CheckoutPaymentBooster\ViewModel\ExpressPay;
 
 /** @var ExpressPay $expressPayViewModel */
 $expressPayViewModel = $block->getData('express_pay_view_model');
-$isEnabled = $expressPayViewModel->isCartWalletPayEnabled();
-$hasActiveQuote = $expressPayViewModel->hasActiveQuote();
+$pageSource = $block->getData('render_page_source');
+$isEnabled = $expressPayViewModel->isEnabled($pageSource);
 
-if (!$isEnabled || !$hasActiveQuote):
+if (!$isEnabled):
     return;
 endif;
 ?>
@@ -23,10 +23,10 @@ endif;
 
 <script>
     if (!window.checkoutConfig) {
-        let newCheckoutConfig = <?= $expressPayViewModel->getJsLayout() ?>;
+        var layout = <?= $expressPayViewModel->getJsLayout() ?>;
 
         window.checkoutConfig = {};
-        Object.assign(window.checkoutConfig, newCheckoutConfig.checkoutConfig);
+        Object.assign(window.checkoutConfig, layout.checkoutConfig);
     }
 </script>
 
@@ -34,6 +34,7 @@ endif;
 {
     "#express-pay-container": {
         "Bold_CheckoutPaymentBooster/js/express-pay-storefront": {
+            "pageSource": "<?= $block->escapeJs($pageSource) ?>"
         }
     }
 }

--- a/view/frontend/web/js/action/express-pay/create-wallet-pay-order-action.js
+++ b/view/frontend/web/js/action/express-pay/create-wallet-pay-order-action.js
@@ -13,7 +13,7 @@ define(
          * @param {{}}
          * @return {Promise}
          */
-        return async function (paymentPayload) {
+        return function (paymentPayload) {
             return platformClient.post(
                 'rest/V1/express_pay/order/create',
                 {

--- a/view/frontend/web/js/action/express-pay/get-active-quote-id-action.js
+++ b/view/frontend/web/js/action/express-pay/get-active-quote-id-action.js
@@ -1,0 +1,20 @@
+define(
+    [
+        'Bold_CheckoutPaymentBooster/js/model/platform-client'
+    ],
+    function (
+        platformClient
+    ) {
+        'use strict';
+
+        /**
+         * Create Wallet Pay order.
+         *
+         * @param {{}}
+         * @return {Promise}
+         */
+        return function () {
+            return platformClient.get('rest/V1/cart/getQuoteId', {});
+        };
+    }
+);

--- a/view/frontend/web/js/express-pay-storefront.js
+++ b/view/frontend/web/js/express-pay-storefront.js
@@ -1,10 +1,12 @@
 define([
     'uiComponent',
+    'ko',
     'underscore',
     'Bold_CheckoutPaymentBooster/js/model/spi',
     'Magento_Customer/js/customer-data'
-], function(
+], function (
     Component,
+    ko,
     _,
     spi,
     customerData
@@ -12,9 +14,14 @@ define([
     'use strict'
 
     return Component.extend({
-        initialize: async function () {
+        defaults: {
+            _pageSource: ko.observable('')
+        },
+
+        initialize: async function (config) {
             this._super();
 
+            this._pageSource(config.pageSource);
             this._initConfig();
             this._setVisibility();
         },
@@ -42,12 +49,10 @@ define([
             const containerId = 'express-pay-buttons';
 
             let boldPaymentsInstance;
-
             try {
-                boldPaymentsInstance = await spi.getPaymentsClient();
+                boldPaymentsInstance = await spi.getPaymentsClient(this._pageSource());
             } catch (error) {
                 console.error('Could not instantiate Bold Payments Client.', error);
-
                 return;
             }
 

--- a/view/frontend/web/js/model/spi/callbacks/on-click-payment-order-callback.js
+++ b/view/frontend/web/js/model/spi/callbacks/on-click-payment-order-callback.js
@@ -1,0 +1,27 @@
+define(['jquery'], function ($) {
+    'use strict';
+    return async function (pageSource) {
+        if (pageSource !== 'product') {
+            return;
+        }
+
+        const productAddToCartForm = document.getElementById('product_addtocart_form');
+
+        const productAddToCartUrl = productAddToCartForm.getAttribute('action');
+        const addToCartFormData = new FormData(productAddToCartForm);
+        addToCartFormData.append('source', 'expresspay');
+
+        if (!($("#product_addtocart_form").validation('isValid'))) {
+            throw new Error('Product form invalid');
+        }
+
+        try {
+            await fetch(productAddToCartUrl, {
+                method: "POST",
+                body: addToCartFormData
+            });
+        } catch (err) {
+            console.log(err);
+        }
+    }
+});


### PR DESCRIPTION
Adding Express Pay modal to the PDP
Adding before cart add event to clear cart for quick purchase 
Adding support for SDK onClick event to add item to cart on pdp 
Adding page source argument to express pay xml to facilitate above add

NOTE: requires fixes in parent branch to implement cache bust causing observer not to fire.