### PR TITLE
EPS-668: Add shop name as option when rendering apple payment button

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/bold-spi.js
+++ b/view/frontend/web/js/view/payment/method-renderer/bold-spi.js
@@ -165,6 +165,7 @@ define([
                 shouldRenderSpiFrame: true,
                 shouldRenderPaypalButton: true,
                 shouldRenderAppleGoogleButtons: true,
+                shopName: window.checkoutConfig.bold?.shopName ?? '',
             }
             paymentsInstance.renderPayments('SPI', paymentOptions);
         },


### PR DESCRIPTION
- Add shop name as option when rendering apple pay button above SPI, the same option has passed in the apple pay express button