### PR TITLE
CHK-6262: Update address on approve payment for wallet pays

### DIFF
--- a/view/frontend/web/js/action/express-pay/update-quote-address-action.js
+++ b/view/frontend/web/js/action/express-pay/update-quote-address-action.js
@@ -59,7 +59,7 @@ define(
                 region_id: regionId
             } : regionName;
             const email = addressData['email'] || quote.shippingAddress.email || quote.billingAddress.email;
-            const phone = addressData['phone'] || quote.shippingAddress.telephone || quote.billingAddress.telephone;
+            const phone = addressData['phone'] || addressData['phoneNumber'] || quote.shippingAddress.telephone || quote.billingAddress.telephone;
             const quoteAddress = magentoAddressConverter.formAddressDataToQuoteAddress(
                 {
                     address_type: addressType,

--- a/view/frontend/web/js/action/express-pay/update-quote-ppcp-action.js
+++ b/view/frontend/web/js/action/express-pay/update-quote-ppcp-action.js
@@ -25,10 +25,6 @@ define(
          * @return {Promise}
          */
         return async function (paymentApprovalData) {
-            const paymentData = paymentApprovalData['payment_data'];
-            const availableWalletTypes = ['apple', 'google'];
-            const isWalletPayment = availableWalletTypes.includes(paymentData.payment_type);
-
             let order;
             try {
                 order = await getExpressPayOrderAction(
@@ -56,11 +52,9 @@ define(
                 return address;
             }
 
-            if (!isWalletPayment) {
-                quote.guestEmail = order.email;
-                updateQuoteAddressAction('shipping', _convertAddress(order.shipping_address, order));
-                updateQuoteAddressAction('billing', _convertAddress(order.billing_address, order));
-            }
+            quote.guestEmail = order.email;
+            updateQuoteAddressAction('shipping', _convertAddress(order.shipping_address, order));
+            updateQuoteAddressAction('billing', _convertAddress(order.billing_address, order));
         };
     }
 );

--- a/view/frontend/web/js/action/express-pay/update-quote-wallet-pay-action.js
+++ b/view/frontend/web/js/action/express-pay/update-quote-wallet-pay-action.js
@@ -1,0 +1,28 @@
+define(
+    [
+        'Bold_CheckoutPaymentBooster/js/action/express-pay/update-quote-address-action',
+    ],
+    function (
+        updateQuoteAddressAction,
+    ) {
+        'use strict';
+
+        /**
+         * Place order action.
+         *
+         * @return {Promise}
+         */
+        return async function (paymentApprovalData) {
+            const paymentData = paymentApprovalData['payment_data'];
+            const customer = paymentData['customer'];
+            const _convertAddress = function (address, customer) {
+                address.email = customer.email_address;
+
+                return address;
+            }
+
+            updateQuoteAddressAction('shipping', _convertAddress(paymentData.shipping_address, customer));
+            updateQuoteAddressAction('billing', _convertAddress(paymentData.billing_address, customer));
+        };
+    }
+);

--- a/view/frontend/web/js/model/spi/callbacks/on-approve-payment-order-callback.js
+++ b/view/frontend/web/js/model/spi/callbacks/on-approve-payment-order-callback.js
@@ -5,6 +5,7 @@ define(
         'Magento_Checkout/js/model/quote',
         'Magento_Checkout/js/action/place-order',
         'Magento_Checkout/js/action/redirect-on-success',
+        'Bold_CheckoutPaymentBooster/js/action/express-pay/update-quote-wallet-pay-action',
         'Bold_CheckoutPaymentBooster/js/action/express-pay/update-quote-ppcp-action',
         'Bold_CheckoutPaymentBooster/js/action/express-pay/update-quote-braintree-action',
         'Bold_CheckoutPaymentBooster/js/action/express-pay/save-shipping-information-action',
@@ -15,6 +16,7 @@ define(
         quote,
         placeOrderAction,
         redirectOnSuccessAction,
+        updateQuoteWalletPayAction,
         updateQuotePPCPAction,
         updateQuoteBraintreeAction,
         saveShippingInformationAction
@@ -48,7 +50,9 @@ define(
                 };
             }
 
-            if (paymentType === 'ppcp') {
+            if (isWalletPayment) {
+                await updateQuoteWalletPayAction(paymentApprovalData);
+            } else if (paymentType === 'ppcp') {
                 await updateQuotePPCPAction(paymentApprovalData);
             } else {
                 await updateQuoteBraintreeAction(paymentInformation, paymentApprovalData);


### PR DESCRIPTION
The email address and phone number are not provided in the `onUpdatePaymentOrder` callback for wallet pays. This change updates the addresses in the `onApprovePaymentOrder` to include this data.

Fixes [CHK-6262](https://boldapps.atlassian.net/browse/CHK-6262)

[CHK-6262]: https://boldapps.atlassian.net/browse/CHK-6262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ