### PR TITLE
CHK-6986 release version 2.2.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "license": [
     "MIT"
   ],
-  "version": "2.2.7",
+  "version": "2.2.8",
   "require": {
     "magento/framework": ">=102.0.1 <103.0.8",
     "magento/module-checkout": ">=100.3.1 <100.4.8",


### PR DESCRIPTION
## What's Changed
* EPS-668: Use class name instead of ID for Express Pay buttons by @zliu7878 in https://github.com/bold-commerce/adobe-commerce-bold-checkout-payment-booster/pull/145
* CHK-6924: Don't remove www. prefix from configuration group label by @benzeghers-bold in https://github.com/bold-commerce/adobe-commerce-bold-checkout-payment-booster/pull/148
* CHK-6869 Remove Prototype Import to Prevent JS Dump by @TimeBones in https://github.com/bold-commerce/adobe-commerce-bold-checkout-payment-booster/pull/146
* EPS-668: Add shop name as option when rendering Apple Pay payment button by @zliu7878 in https://github.com/bold-commerce/adobe-commerce-bold-checkout-payment-booster/pull/149

Resolves [CHK-6986](https://boldapps.atlassian.net/browse/CHK-6986)

[CHK-6986]: https://boldapps.atlassian.net/browse/CHK-6986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ