### PR TITLE
CHK-7004 - filter out shipping options in PayPal request that Magento could not import

### DIFF
--- a/Service/ExpressPay/QuoteConverter.php
+++ b/Service/ExpressPay/QuoteConverter.php
@@ -167,6 +167,13 @@ class QuoteConverter
         $hasRequiredAddressData = ($shippingAddress->getCity() && $shippingAddress->getCountryId());
 
         if ($hasRequiredAddressData && count($shippingRates) > 0) {
+            $validShippingRates = array_filter(
+                $shippingRates,
+                static function (Rate $rate): bool {
+                    return substr($rate->getCode(), -strlen('_error')) !== '_error';
+                }
+            );  //filter out Rates Magento could not import
+
             $convertedQuote['order_data']['shipping_options'] = array_map(
                 static function (Rate $rate) use ($currencyCode, $shippingAddress): array {
                     $price = ($rate->getCode() === $shippingAddress->getShippingMethod())
@@ -181,7 +188,7 @@ class QuoteConverter
                         ]
                     ];
                 },
-                $shippingRates
+                $validShippingRates
             );
         }
 


### PR DESCRIPTION
Fixes a bug where a shipping rate was not imported successfully, but still sent to PayPal as part of the order creation request. This caused an issue since PayPal validates that shipping options must have a label.

Added a bit of code to ignore failed rate imports in the PayPal request.