### PR TITLE
CHK-6516 - support for non-string tax identifiers in Magento tax zones

### DIFF
--- a/Model/Order/HydrateOrderFromQuote.php
+++ b/Model/Order/HydrateOrderFromQuote.php
@@ -179,7 +179,7 @@ class HydrateOrderFromQuote
 
         foreach ($taxes as $tax) {
             $taxLines[] = [
-                'name' => $tax['id'],
+                'name' => strval($tax['id']),
                 'value' => $this->convertToCents($tax['base_amount']),
             ];
         }


### PR DESCRIPTION
In Magento it is possible to save Tax Zones with numeric `tax identifiers`. We use this field as the rate/display name in the simple order. 

When saving an integral value in the tax identifier, the Sidekick hydrate order request fails due to this value being an integer, with the Sidekick API expecting a string.

![Screenshot 2024-12-23 at 3 34 15 PM](https://github.com/user-attachments/assets/e42cc562-b1db-47ee-a4c8-6b57104b1745)
