### PR TITLE
[CHK-7028] Add google pay button to wallet pay options when fastlane enabled

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/bold-spi.js
+++ b/view/frontend/web/js/view/payment/method-renderer/bold-spi.js
@@ -148,7 +148,10 @@ define([
             if (isFastlaneAvailable) {
                 const fastlaneOptions = {
                     fastlane: isFastlaneAvailable,
-                    shouldRenderSpiFrame: false
+                    shouldRenderSpiFrame: false,
+                    shouldRenderPaypalButton: true,
+                    shouldRenderAppleGoogleButtons: true,
+                    shopName: window.checkoutConfig.bold?.shopName ?? '',
                 };
                 paymentsInstance.renderPayments('SPI', fastlaneOptions);
                 this.isBillingAddressRequired(false);


### PR DESCRIPTION
#### Overview

Adding the ability to show the Google Pay button in the wallet pays payment section when fastlane is enabled.
![image](https://github.com/user-attachments/assets/58ba4900-c790-4b35-af63-618ce4675a45)

Resolves [CHK-7028](https://boldapps.atlassian.net/browse/CHK-7028)


[CHK-7028]: https://boldapps.atlassian.net/browse/CHK-7028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ