### PR TITLE
CHK-4774 Add error message for invalid CC details in SPI

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/bold-spi.js
+++ b/view/frontend/web/js/view/payment/method-renderer/bold-spi.js
@@ -285,7 +285,7 @@ define([
                         }
                         if (paymentId === undefined && data.payload?.success === false) {
                             // Error message for empty or invalid CC details, temporary fix until CHK-7079 is resolved
-                            messageList.addErrorMessage({message: $t('Payment failed, please try again. For digital wallet payments, please click the wallet button to proceed')});
+                            messageList.addErrorMessage({message: $t('Payment failed. Please try again or select a different payment method in the "Pay With" section.')});
                         }
                     case 'EVENT_SPI_TOKENIZE_FAILED':
                         this.paymentId(null);

--- a/view/frontend/web/js/view/payment/method-renderer/bold-spi.js
+++ b/view/frontend/web/js/view/payment/method-renderer/bold-spi.js
@@ -274,18 +274,19 @@ define([
                         break;
                     case 'EVENT_SPI_TOKENIZED':
                         const paymentId = data.payload?.payload?.data?.payment_id;
-                        if (!paymentId) {
-                            fullscreenLoader.stopLoader();
+                        if (paymentId) {
+                            this.paymentId(paymentId);
+    
+                            const placeOrderSuccess = this.placeOrder({}, jQuery.Event());
+                            if (!placeOrderSuccess) {
+                                fullscreenLoader.stopLoader();
+                            }
                             return;
                         }
-                        this.paymentId(paymentId);
-
-                        const placeOrderSuccess = this.placeOrder({}, jQuery.Event());
-                        if (!placeOrderSuccess) {
-                            fullscreenLoader.stopLoader();
+                        if (paymentId === undefined && data.payload?.success === false) {
+                            // Error message for empty or invalid CC details, temporary fix until CHK-7079 is resolved
+                            messageList.addErrorMessage({message: $t('Payment failed, please try again. For digital wallet payments, please click the wallet button to proceed')});
                         }
-
-                        break;
                     case 'EVENT_SPI_TOKENIZE_FAILED':
                         this.paymentId(null);
                         console.log('Failed to tokenize');


### PR DESCRIPTION
Add an error for SPI tokenize event that is unsuccessful and there is no payment ID. Additionally if the tokenize does not have a payment id the case will flow into the SPI tokenize failed so clear loading states and the payment id observable. This is because SPI can return the tokenized even with `success: false` in addition to the tokenized failed as separate events.

![image](https://github.com/user-attachments/assets/f6e5f42f-bd56-4bb8-9cca-eb4649036921)

Fixes [CHK-4774](https://boldapps.atlassian.net/browse/CHK-4774)


[CHK-4774]: https://boldapps.atlassian.net/browse/CHK-4774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ