### PR TITLE
CHK-6966: Don't update address when not express pay

### DIFF
--- a/view/frontend/web/js/model/spi/callbacks/on-create-payment-order-callback.js
+++ b/view/frontend/web/js/model/spi/callbacks/on-create-payment-order-callback.js
@@ -23,23 +23,26 @@ define(
             const paymentData = paymentPayload['payment_data'];
             const availableWalletTypes = ['apple', 'google'];
             const isWalletPayment = availableWalletTypes.includes(paymentData.payment_type);
+            const isSpiContainer = paymentPayload.containerId === 'SPI';
 
             if (paymentType !== 'ppcp') {
                 return;
             }
 
-            if (isWalletPayment) {
-                if (paymentData['shipping_address']) {
-                    updateQuoteAddressAction('shipping', paymentData['shipping_address']);
+            if (!isSpiContainer) {
+                if (isWalletPayment) {
+                    if (paymentData['shipping_address']) {
+                        updateQuoteAddressAction('shipping', paymentData['shipping_address']);
+                    }
+                    if (paymentData['billing_address']) {
+                        updateQuoteAddressAction('billing', paymentData['billing_address']);
+                    }
+                } else {
+                    await updateQuoteShippingMethodAction(paymentData['shipping_options']);
                 }
-                if (paymentData['billing_address']) {
-                    updateQuoteAddressAction('billing', paymentData['billing_address']);
-                }
-            } else {
-                await updateQuoteShippingMethodAction(paymentData['shipping_options']);
-            }
 
-            await saveShippingInformationAction(true);
+                await saveShippingInformationAction(true);
+            }
 
             const walletPayResult = await createWalletPayOrderAction(paymentPayload);
             return {


### PR DESCRIPTION
For non-express pay orders, the customer would enter their address but then it would be replaced with the address from PayPal. This change keeps the address the customer entered in Magento.

Related EPS change: https://github.com/bold-commerce/enhanced-payment-service/pull/500

Fixes [CHK-6966](https://boldapps.atlassian.net/browse/CHK-6966)

[CHK-6966]: https://boldapps.atlassian.net/browse/CHK-6966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ