### PR TITLE
[CHK-7145] Fix Quote Initialization for Apple Pay on Product Detail Page

### DIFF
--- a/Api/Quote/GetQuoteInterface.php
+++ b/Api/Quote/GetQuoteInterface.php
@@ -15,5 +15,5 @@ interface GetQuoteInterface
      * @return string
      * @throws \Magento\Framework\Exception\LocalizedException
      */
-    public function getQuoteId();
+    public function getQuote();
 }

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -333,7 +333,7 @@ class Config
             ScopeInterface::SCOPE_WEBSITES,
             $websiteId
         );
-    }    
+    }
     
     /**
      * Check if Wallet Express Pay buttons are enabled on the product pages.

--- a/Service/Quote/GetQuote.php
+++ b/Service/Quote/GetQuote.php
@@ -69,7 +69,7 @@ class GetQuote implements GetQuoteInterface
      * @return string
      * @throws \Magento\Framework\Exception\LocalizedException
      */
-    public function getQuote()
+    public function getQuote(): string
     {
         $quoteId = (int)$this->checkoutSession->getQuote()->getId();
         $result['quoteId'] = $this->quoteIdToMaskedQuoteId->execute($quoteId);
@@ -83,7 +83,7 @@ class GetQuote implements GetQuoteInterface
      *
      * @return array
      */
-    private function getQuoteItemData()
+    private function getQuoteItemData(): array
     {
         $quoteItemData = [];
         $quoteId = $this->checkoutSession->getQuote()->getId();
@@ -108,12 +108,12 @@ class GetQuote implements GetQuoteInterface
      * @param \Magento\Quote\Api\Data\CartItemInterface $item
      * @return array
      */
-    protected function getFormattedOptionValue($item)
+    protected function getFormattedOptionValue($item): array
     {
         $optionsData = [];
         $options = $this->configurationPool->getByProductType($item->getProductType())->getOptions($item);
         foreach ($options as $index => $optionValue) {
-            /* @var $helper \Magento\Catalog\Helper\Product\Configuration */
+            /* @var \Magento\Catalog\Helper\Product\Configuration $helper */
             $helper = $this->configurationPool->getByProductType('default');
             $params = [
                 'max_length' => 55,

--- a/Service/Quote/GetQuote.php
+++ b/Service/Quote/GetQuote.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace Bold\CheckoutPaymentBooster\Service\Quote;
 
+
+use Magento\Quote\Api\CartItemRepositoryInterface as QuoteItemRepository;
+use Magento\Catalog\Helper\Product\ConfigurationPool;
 use Bold\CheckoutPaymentBooster\Api\Quote\GetQuoteInterface;
+use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Checkout\Model\Session;
 use Magento\Quote\Model\QuoteIdToMaskedQuoteIdInterface;
 
@@ -21,14 +25,42 @@ class GetQuote implements GetQuoteInterface
     /**
      * @var QuoteIdToMaskedQuoteId
      */
-    private $quoteIdToMaskedQuoteId;
+    private $quoteIdToMaskedQuoteId;    
+
+    /**
+     * @var QuoteItemRepository
+     */
+    private $quoteItemRepository;
+    
+    /**
+     * @var SerializerInterface
+     */
+    private $serializer;
+
+    /**
+     * @var ConfigurationPool
+     */
+    private $configurationPool;
+
+    /**
+     * @var \Magento\Catalog\Helper\Image
+     */
+    protected $imageHelper;
 
     public function __construct(
         Session $checkoutSession,
-        QuoteIdToMaskedQuoteIdInterface $quoteIdToMaskedQuoteId
+        QuoteIdToMaskedQuoteIdInterface $quoteIdToMaskedQuoteId,
+        QuoteItemRepository $quoteItemRepository,
+        SerializerInterface $serializer,
+        ConfigurationPool $configurationPool,
+        \Magento\Catalog\Helper\Image $imageHelper
     ) {
         $this->checkoutSession = $checkoutSession;
         $this->quoteIdToMaskedQuoteId = $quoteIdToMaskedQuoteId;
+        $this->quoteItemRepository = $quoteItemRepository;
+        $this->serializer = $serializer;
+        $this->configurationPool = $configurationPool;
+        $this->imageHelper = $imageHelper;
     }
 
     /**
@@ -37,11 +69,60 @@ class GetQuote implements GetQuoteInterface
      * @return string
      * @throws \Magento\Framework\Exception\LocalizedException
      */
-    public function getQuoteId()
+    public function getQuote()
     {
         $quoteId = (int)$this->checkoutSession->getQuote()->getId();
-        $quoteIdMask = $this->quoteIdToMaskedQuoteId->execute($quoteId);
+        $result['quoteId'] = $this->quoteIdToMaskedQuoteId->execute($quoteId);
+        $result['quoteItemData'] = $this->getQuoteItemData();
 
-        return $quoteIdMask;
+        return $this->serializer->serialize($result);
+    }
+
+    /**
+     * Retrieve quote item data
+     *
+     * @return array
+     */
+    private function getQuoteItemData()
+    {
+        $quoteItemData = [];
+        $quoteId = $this->checkoutSession->getQuote()->getId();
+        if ($quoteId) {
+            $quoteItems = $this->quoteItemRepository->getList($quoteId);
+            foreach ($quoteItems as $index => $quoteItem) {
+                $quoteItemData[$index] = $quoteItem->toArray();
+                $quoteItemData[$index]['options'] = $this->getFormattedOptionValue($quoteItem);
+                $quoteItemData[$index]['thumbnail'] = $this->imageHelper->init(
+                    $quoteItem->getProduct(),
+                    'product_thumbnail_image'
+                )->getUrl();
+                $quoteItemData[$index]['message'] = $quoteItem->getMessage();
+            }
+        }
+        return $quoteItemData;
+    }
+
+        /**
+     * Retrieve formatted item options view
+     *
+     * @param \Magento\Quote\Api\Data\CartItemInterface $item
+     * @return array
+     */
+    protected function getFormattedOptionValue($item)
+    {
+        $optionsData = [];
+        $options = $this->configurationPool->getByProductType($item->getProductType())->getOptions($item);
+        foreach ($options as $index => $optionValue) {
+            /* @var $helper \Magento\Catalog\Helper\Product\Configuration */
+            $helper = $this->configurationPool->getByProductType('default');
+            $params = [
+                'max_length' => 55,
+                'cut_replacer' => ' <a href="#" class="dots tooltip toggle" onclick="return false">...</a>'
+            ];
+            $option = $helper->getFormattedOptionValue($optionValue, $params);
+            $optionsData[$index] = $option;
+            $optionsData[$index]['label'] = $optionValue['label'];
+        }
+        return $optionsData;
     }
 }

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -64,8 +64,8 @@
             <resource ref="anonymous" />
         </resources>
     </route>    
-    <route url="/V1/cart/getQuoteId" method="GET">
-        <service class="Bold\CheckoutPaymentBooster\Api\Quote\GetQuoteInterface" method="getQuoteId"/>
+    <route url="/V1/cart/getQuote" method="GET">
+        <service class="Bold\CheckoutPaymentBooster\Api\Quote\GetQuoteInterface" method="getQuote"/>
         <resources>
             <resource ref="anonymous" />
         </resources>

--- a/view/frontend/web/js/action/express-pay/add-product-to-cart-action.js
+++ b/view/frontend/web/js/action/express-pay/add-product-to-cart-action.js
@@ -1,0 +1,29 @@
+define([
+    'jquery'
+], function (
+    $
+) {
+    'use strict';
+    return function () {
+        const productAddToCartForm = document.getElementById('product_addtocart_form');
+
+        const productAddToCartUrl = productAddToCartForm.getAttribute('action');
+        const addToCartFormData = new FormData(productAddToCartForm);
+        addToCartFormData.append('source', 'expresspay');
+
+        if (!($("#product_addtocart_form").validation('isValid'))) {
+            throw new Error('Product form invalid');
+        }
+
+        try {
+            return fetch(productAddToCartUrl, {
+                method: "POST",
+                headers: {},
+                body: addToCartFormData,
+                credentials: 'same-origin'
+            });
+        } catch (err) {
+            console.error(err);
+        }
+    }
+});

--- a/view/frontend/web/js/action/express-pay/get-active-quote-action.js
+++ b/view/frontend/web/js/action/express-pay/get-active-quote-action.js
@@ -14,7 +14,7 @@ define(
          * @return {Promise}
          */
         return function () {
-            return platformClient.get('rest/V1/cart/getQuoteId', {});
+            return platformClient.get('rest/V1/cart/getQuote', {});
         };
     }
 );

--- a/view/frontend/web/js/action/express-pay/get-required-order-data-action.js
+++ b/view/frontend/web/js/action/express-pay/get-required-order-data-action.js
@@ -20,7 +20,20 @@ define(
          */
         return function (requirements) {
             const payload = {};
+            if (window.checkoutConfig.bold.payment_type_clicked == 'apple') {
+                payload.totals = {
+                    order_total: 0,
+                    order_balance: 1000,
+                    shipping_total: 0,
+                    discounts_total: 0,
+                    fees_total: 0,
+                    taxes_total: 0
+                };
+                payload.items = [{label: '', amount: 0}];
+                payload.shipping_address = {};
 
+                return payload;
+            };
             for (const requirement of requirements) {
                 switch (requirement) {
                     case 'customer':
@@ -42,10 +55,12 @@ define(
                         }));
                         break;
                     case 'billing_address':
-                        payload[requirement] = convertMagentoAddressAction(quote.billingAddress());
+                        const hasBillingAddress = quote.billingAddress() !== null;
+                        payload[requirement] = hasBillingAddress !== null ? convertMagentoAddressAction(quote.billingAddress()) : {};
                         break;
                     case 'shipping_address':
-                        payload[requirement] = convertMagentoAddressAction(quote.shippingAddress());
+                        const hasShippingAddress = quote.shippingAddress() !== null;
+                        payload[requirement] = hasShippingAddress ? convertMagentoAddressAction(quote.shippingAddress()) : {};
                         break;
                     case 'shipping_options':
                         payload[requirement] = shippingService.getShippingRates().map(option => ({

--- a/view/frontend/web/js/model/spi.js
+++ b/view/frontend/web/js/model/spi.js
@@ -4,7 +4,6 @@ define([
     'Magento_Checkout/js/model/payment/additional-validators',
     'Bold_CheckoutPaymentBooster/js/model/fastlane',
     'Bold_CheckoutPaymentBooster/js/action/general/load-script-action',
-    'Bold_CheckoutPaymentBooster/js/action/express-pay/get-active-quote-id-action',
     'Bold_CheckoutPaymentBooster/js/model/spi/callbacks/on-create-payment-order-callback',
     'Bold_CheckoutPaymentBooster/js/model/spi/callbacks/on-update-payment-order-callback',
     'Bold_CheckoutPaymentBooster/js/model/spi/callbacks/on-require-order-data-callback',
@@ -20,7 +19,6 @@ define([
     additionalValidators,
     fastlane,
     loadScriptAction,
-    getActiveQuoteId,
     onCreatePaymentOrderCallback,
     onUpdatePaymentOrderCallback,
     onRequireOrderDataCallback,
@@ -143,7 +141,7 @@ define([
                     },
                     'onRequireOrderData': async function (requirements) {
                         try {
-                            return await onRequireOrderDataCallback(requirements);
+                            return onRequireOrderDataCallback(requirements);
                         } catch (e) {
                             console.error(e);
                             fullScreenLoader.stopLoader();
@@ -154,17 +152,11 @@ define([
                         console.error('An unexpected PayPal error occurred', errors);
                         messageList.addErrorMessage({ message: 'Warning: An unexpected error occurred. Please try again.' });
                     },
-                    'onClickPaymentOrder': async function () {
-                        try {
-                            await onClickPaymentOrderCallback(pageSource);
-                            let isQuoteInitialized = window.checkoutConfig.quoteData.entity_id !== '';
-                            if (isQuoteInitialized) {
-                                return;
-                            }
-
-                            let response = await getActiveQuoteId();
-
-                            window.checkoutConfig.quoteData.entity_id = response;
+                    'onClickPaymentOrder': async (type, payload) => {
+                        try {                            
+                            window.checkoutConfig.bold.payment_type_clicked = payload?.payment_data?.payment_type;
+                            
+                            onClickPaymentOrderCallback(pageSource);
                         } catch (e) {
                             console.error(e);
                             fullScreenLoader.stopLoader();

--- a/view/frontend/web/js/model/spi/callbacks/on-click-payment-order-callback.js
+++ b/view/frontend/web/js/model/spi/callbacks/on-click-payment-order-callback.js
@@ -1,27 +1,31 @@
-define(['jquery'], function ($) {
+define([
+    'jquery',
+    'Bold_CheckoutPaymentBooster/js/action/express-pay/add-product-to-cart-action',
+    'Bold_CheckoutPaymentBooster/js/action/express-pay/get-active-quote-action'
+], function (
+    $,
+    addProductToCart,
+    getActiveQuote
+) {
     'use strict';
     return async function (pageSource) {
         if (pageSource !== 'product-details') {
             return;
         }
 
-        const productAddToCartForm = document.getElementById('product_addtocart_form');
-
-        const productAddToCartUrl = productAddToCartForm.getAttribute('action');
-        const addToCartFormData = new FormData(productAddToCartForm);
-        addToCartFormData.append('source', 'expresspay');
-
-        if (!($("#product_addtocart_form").validation('isValid'))) {
-            throw new Error('Product form invalid');
-        }
-
         try {
-            await fetch(productAddToCartUrl, {
-                method: "POST",
-                body: addToCartFormData
-            });
+            await addProductToCart();
+            let isQuoteInitialized = window.checkoutConfig.quoteData.entity_id !== '';
+            if (isQuoteInitialized) {
+                return;
+            }
+
+            let response = await getActiveQuote();
+            response = JSON.parse(response);
+            window.checkoutConfig.quoteData.entity_id = response.quoteId;
+            window.checkoutConfig.quoteItemData = response.quoteItemData;
         } catch (err) {
-            console.log(err);
+            console.error(err);
         }
     }
 });


### PR DESCRIPTION
Removing Awaits in onclick functionality to allow apple pay to render immediately.
Adding default data in onrequire for apply pay orders so the data is instead populated in the onupdate event to facilitate this.

Note that future state for this fix will include more accurate dummy data and guards around possible race conditions. That fix will be included in [CHK-7179]

Fixes [CHK-7145](https://boldapps.atlassian.net/browse/CHK-7145)

[CHK-7179]: https://boldapps.atlassian.net/browse/CHK-7179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CHK-7145]: https://boldapps.atlassian.net/browse/CHK-7145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ