### PR TITLE
Release version 2.2.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "license": [
     "MIT"
   ],
-  "version": "2.2.10",
+  "version": "2.2.11",
   "require": {
     "magento/framework": ">=102.0.1 <103.0.8",
     "magento/module-checkout": ">=100.3.1 <100.4.8",


### PR DESCRIPTION
* CHK-4774 Add error message for invalid CC details in SPI by @TimeBones in https://github.com/bold-commerce/adobe-commerce-bold-checkout-payment-booster/pull/161


- [x] E2E tests pass
- [x] Manually Test Apple Pay
- [x] Manually Test Google Pay