### PR TITLE
CHK-7244 Keep Shipping Name and Email for Paypal Wallet Pay Orders

### DIFF
--- a/view/frontend/web/js/action/express-pay/update-quote-ppcp-action.js
+++ b/view/frontend/web/js/action/express-pay/update-quote-ppcp-action.js
@@ -1,19 +1,11 @@
 define(
     [
-        'uiRegistry',
-        'jquery',
         'Magento_Checkout/js/model/quote',
-        'Magento_Checkout/js/action/place-order',
-        'Magento_Checkout/js/action/redirect-on-success',
         'Bold_CheckoutPaymentBooster/js/action/express-pay/get-express-pay-order-action',
         'Bold_CheckoutPaymentBooster/js/action/express-pay/update-quote-address-action',
     ],
     function (
-        registry,
-        $,
         quote,
-        placeOrderAction,
-        redirectOnSuccessAction,
         getExpressPayOrderAction,
         updateQuoteAddressAction,
     ) {
@@ -52,8 +44,10 @@ define(
                 return address;
             }
 
-            quote.guestEmail = order.email;
-            updateQuoteAddressAction('shipping', _convertAddress(order.shipping_address, order));
+            if (paymentApprovalData.shipping_strategy !== 'fixed') {
+                quote.guestEmail = order.email;
+                updateQuoteAddressAction('shipping', _convertAddress(order.shipping_address, order));
+            }
             updateQuoteAddressAction('billing', _convertAddress(order.billing_address, order));
         };
     }


### PR DESCRIPTION
PayPal Wallet Pay Orders were replacing the shipping address first and last name as well as the order email with the billing address (from paypal). 

Checking the shipping strategy to be fixed, then we know that the user will have these filled out already and we don't need to update them on the magento order.

Also removed some obsolete imports 