### PR TITLE
[CHK-7161] Adobe Commerce: Remove "Added to cart" alert on checkout success page

### DIFF
--- a/Observer/Product/ExpressPayAfterAddToCartObserver.php
+++ b/Observer/Product/ExpressPayAfterAddToCartObserver.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\CheckoutPaymentBooster\Observer\Product;
+
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\Message\ManagerInterface;
+
+/**
+ * Observer for 'checkout_cart_add_product_complete' event
+ *
+ * @see \Magento\Checkout\Controller\Cart\Add::execute
+ */
+class ExpressPayAfterAddToCartObserver implements ObserverInterface
+{
+    /**
+     * @var ManagerInterface
+     */
+    private $messageManager;
+
+    const ADD_TO_CART_SUCCESS_MESSAGE = 'addCartSuccessMessage';
+
+    public function __contruct(ManagerInterface $messageManager)
+    {
+        $this->messageManager = $messageManager;
+    }
+
+    /**
+     * Clear the add to cart message after adding from PDP
+     *
+     * @param Observer $observer
+     * @return void
+     */
+    public function execute(Observer $observer): void
+    {
+        $request = $observer->getEvent()->getRequest();
+        $isExpressPayOrder = $request->getParam('source') === 'expresspay';
+
+        if (!$isExpressPayOrder) {
+            return;
+        }
+
+        $this->messageManager->getMessages()->deleteMessageByIdentifier(ExpressPayAfterAddToCartObserver::ADD_TO_CART_SUCCESS_MESSAGE);
+    }
+}

--- a/etc/frontend/events.xml
+++ b/etc/frontend/events.xml
@@ -3,6 +3,9 @@
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">  
     <event name="controller_action_predispatch_checkout_cart_add">
         <observer name="express_pay_before_add_to_cart" instance="Bold\CheckoutPaymentBooster\Observer\Product\ExpressPayBeforeAddToCartObserver"/>
+    </event>    
+    <event name="checkout_cart_add_product_complete">
+        <observer name="express_pay_after_add_to_cart" instance="Bold\CheckoutPaymentBooster\Observer\Product\ExpressPayAfterAddToCartObserver"/>
     </event>
     <event name="shortcut_buttons_container">
         <observer name="add_express_pay_buttons" instance="Bold\CheckoutPaymentBooster\Observer\ShortcutButtons\AddExpressPayButtonsObserver"/>


### PR DESCRIPTION
Adding after add dispatch event to supress add to cart message appearing on checkout/add

Fixes [CHK-7161](https://boldapps.atlassian.net/browse/CHK-7161)

[CHK-7161]: https://boldapps.atlassian.net/browse/CHK-7161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ