### PR TITLE
CHK-7483: Non Express wallet pay shipping data

### DIFF
--- a/view/frontend/web/js/action/express-pay/update-quote-ppcp-action.js
+++ b/view/frontend/web/js/action/express-pay/update-quote-ppcp-action.js
@@ -41,6 +41,7 @@ define(
                 address.last_name = order.last_name;
                 address.state = address.province;
                 address.country_code = address.country;
+                address.telephone = address.phone;
 
                 if (!address.email && order.email) {
                     address.email = order.email;
@@ -48,13 +49,17 @@ define(
 
                 delete address.province;
                 delete address.country;
+                delete address.phone;
 
                 return address;
             }
 
             quote.guestEmail = order.email;
-            updateQuoteAddressAction('shipping', _convertAddress(order.shipping_address, order));
             updateQuoteAddressAction('billing', _convertAddress(order.billing_address, order));
+
+            if (paymentApprovalData.shipping_strategy === 'dynamic') {
+                updateQuoteAddressAction('shipping', _convertAddress(order.shipping_address, order));
+            }
         };
     }
 );


### PR DESCRIPTION
- Fixed an issue where non-express wallet-pay shipping data collected by Magento was being replaced with Paypal order data which may not be accurate to the quote.

Fixes [CHK-7483](https://boldapps.atlassian.net/browse/CHK-7483)

[CHK-7483]: https://boldapps.atlassian.net/browse/CHK-7483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ