### PR TITLE
[CHK-7528] Reset paymentId on placeOrderClick

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/bold-spi.js
+++ b/view/frontend/web/js/view/payment/method-renderer/bold-spi.js
@@ -214,6 +214,8 @@ define([
          * @return boolean
          */
         placeOrderClick: function (data, event) {
+            this.paymentId(null);
+
             if (!validateAgreements()) {
                 throw new Error('Agreements not accepted');
             }


### PR DESCRIPTION
Resolves: [CHK-7528](https://boldapps.atlassian.net/browse/CHK-7528)

Set the paymentId to null on `placeOrderClick` ensuring that a new tokenize call is made on each place order attempt. 

This resolves the issue where after an initial transaction decline, subsequent valid payments would not succeed.

[CHK-7528]: https://boldapps.atlassian.net/browse/CHK-7528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ