### PR TITLE
CHK-7553: Fix Error Preventing Stripe Credit Card Form From Loading

### DIFF
--- a/view/frontend/web/js/model/spi.js
+++ b/view/frontend/web/js/model/spi.js
@@ -159,7 +159,7 @@ define([
                             throw e;
                         }
                     },
-                    'onRequireOrderData': function (requirements) {
+                    'onRequireOrderData': async function (requirements) {
                         try {
                             return onRequireOrderDataCallback(requirements);
                         } catch (e) {
@@ -168,7 +168,7 @@ define([
                             throw e;
                         }
                     },
-                    'onErrorPaymentOrder': function (errors) {
+                    'onErrorPaymentOrder': async function (errors) {
                         console.error('An unexpected PayPal error occurred', errors);
                         messageList.addErrorMessage({ message: 'Warning: An unexpected error occurred. Please try again.' });
                     }


### PR DESCRIPTION
(Magento 2/Bold Booster v2) Stripe Credit card frame is not loaded in Payment section with payment_sdk error in Console

Fixes [CHK-7553](https://boldapps.atlassian.net/browse/CHK-7553)

[CHK-7553]: https://boldapps.atlassian.net/browse/CHK-7553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ