### PR TITLE
CHK-7565: Hide Enable Digital Wallets on Cart Page setting when Payment Booster is disabled

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -62,11 +62,17 @@
                     <label>Enable Digital Wallets on Cart Page</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment><![CDATA[Display Digital Wallets on your cart page.]]></comment>
+                    <depends>
+                        <field id="is_payment_booster_enabled">1</field>
+                    </depends>
                 </field>
                 <!-- <field id="is_product_wallet_pay_enabled" translate="label" type="select" sortOrder="70" showInDefault="1" showInWebsite="1">
                     <label>Enable Digital Wallets on Product Pages</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment><![CDATA[Display Digital Wallets on your product pages.]]></comment>
+                    <depends>
+                        <field id="is_payment_booster_enabled">1</field>
+                    </depends>
                 </field> -->
             </group>
             <group id="bold_checkout_payment_booster_advanced" translate="label" sortOrder="160" showInDefault="1" showInWebsite="1">


### PR DESCRIPTION
Fixes [CHK-7565](https://boldapps.atlassian.net/browse/CHK-7565)

[CHK-7565]: https://boldapps.atlassian.net/browse/CHK-7565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ