### PR TITLE
[CHK-7418] - Fix missing phone number on addresses

### DIFF
--- a/view/frontend/web/js/action/express-pay/update-quote-address-action.js
+++ b/view/frontend/web/js/action/express-pay/update-quote-address-action.js
@@ -65,7 +65,11 @@ define(
                 region_id: regionId
             } : regionName;
             const email = addressData['email'] || quote.shippingAddress.email || quote.billingAddress.email;
-            const phone = addressData['phone'] || addressData['phoneNumber'] || quote.shippingAddress.telephone || quote.billingAddress.telephone;
+            const phone = addressData['phone']
+                || addressData['telephone']
+                || addressData['phoneNumber']
+                || quote.shippingAddress.telephone
+                || quote.billingAddress.telephone;
             const quoteAddress = magentoAddressConverter.formAddressDataToQuoteAddress(
                 {
                     address_type: addressType,

--- a/view/frontend/web/js/action/express-pay/update-quote-ppcp-action.js
+++ b/view/frontend/web/js/action/express-pay/update-quote-ppcp-action.js
@@ -37,11 +37,13 @@ define(
                 return;
             }
             const _convertAddress = function (address, order) {
+                let phone = address.phone || order.billing_address.telephone || order.billing_address.phone;
+
                 address.first_name = order.first_name;
                 address.last_name = order.last_name;
                 address.state = address.province;
                 address.country_code = address.country;
-                address.telephone = address.phone;
+                address.telephone = phone;
 
                 if (!address.email && order.email) {
                     address.email = order.email;


### PR DESCRIPTION
Resolves: [CHK-7418](https://boldapps.atlassian.net/browse/CHK-7418)

Fix issue where no phone number was being saved on the shipping or billing address of an order. 

Add missing check for gathering the phone number in the update address action. Also updated our address converter to fallback to the billing address phone number if no number is explicitly provided with the shipping address. 

![image](https://github.com/user-attachments/assets/93d22c22-72c4-4b9b-85a4-5db19f4acba1)


[CHK-7418]: https://boldapps.atlassian.net/browse/CHK-7418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ