### PR TITLE
CHK-7629: Update CSP Whitelist for 2.4.x Versions and Add Compatibility Patch for 2.3.x Versions

### DIFF
--- a/PATCHES.md
+++ b/PATCHES.md
@@ -19,3 +19,4 @@ cp vendor/bold-commerce/module-checkout/patches/[file].patch m2-hotfixes
 |-------------------------------|-----------------|-------------------------------------------------|
 | MAGETWO-PAYMENT-BOOSTER_2.3.1 | <= 2.3.1        | Compatability fix for Payment Booster           |
 | MAGETWO-PAYMENT-BOOSTER_2.3.4 | <= 2.3.4        | Compatability fix for Payment Booster           |
+| MAGETWO-PAYMENT-BOOSTER_2.3.x | <= 2.3.x        | Compatability fix for Payment Booster           |

--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -7,7 +7,7 @@
                 <value id="bold_commerce" type="host">api.boldcommerce.com</value>
                 <value id="bold_commerce_staging" type="host">api.staging.boldcommerce.com</value>
                 <value id="bold_commerce_eps_staging" type="host">eps.secure.staging.boldcommerce.com</value>
-                <value id="cashier" type="host">cashier.boldcommerce.com</value>
+                <value id="bold_cashier" type="host">cashier.boldcommerce.com</value>
                 <value id="bold_braintree_sandbox" type="host">*.sandbox.braintree-api.com</value>
                 <value id="bold_braintree" type="host">*.braintree-api.com</value>
                 <value id="bold_paypal" type="host">*.paypal.com</value>
@@ -23,19 +23,18 @@
         </policy>
         <policy id="script-src">
             <values>
-                <value id="allow_inline_resource" type="host">unsafe-inline</value>
                 <value id="bold_commerce" type="host">api.boldcommerce.com</value>
                 <value id="bold_commerce_staging" type="host">api.staging.boldcommerce.com</value>
                 <value id="bold_commerce_eps_staging" type="host">eps.secure.staging.boldcommerce.com</value>
-                <value id="cashier" type="host">cashier.boldcommerce.com</value>
+                <value id="bold_cashier" type="host">cashier.boldcommerce.com</value>
                 <value id="bold_paypal" type="host">*.paypal.com</value>
                 <value id="bold_paypal_objects" type="host">*.paypalobjects.com</value>
                 <value id="bold_static_eps" type="host">static-eps.secure.boldcommerce.com</value>
                 <value id="bold_static_eps_staging" type="host">static-eps.secure.staging.boldcommerce.com</value>
-                <value id="bold_paypal_script" type="hash" algorithm="sha256">1ozuCt5fPv779wJQEWXLF2gXag+V1bnu3hmAhDbY0Cg=</value>
                 <value id="bold_local" type="host">*.bold.ninja</value>
                 <value id="bold_applepay_script" type="host">*.cdn-apple.com</value>
                 <value id="bold_stripe" type="host">*.stripe.com</value>
+                <value id="bold_inline_script_hash" type="hash" algorithm="sha256">7nnKyr+RUZ9a44Hg3lYwjgkUx5VyFQwv2ZUhVw6N7J4=</value>
             </values>
         </policy>
         <policy id="frame-src">
@@ -46,6 +45,7 @@
                 <value id="bold_local" type="host">*.bold.ninja</value>
                 <value id="bold_static_eps" type="host">static-eps.secure.boldcommerce.com</value>
                 <value id="bold_static_eps_staging" type="host">static-eps.secure.staging.boldcommerce.com</value>
+                <value id="bold_stripe" type="host">*.stripe.com</value>
             </values>
         </policy>
         <policy id="object-src">

--- a/patches/MAGETWO-PAYMENT-BOOSTER_2.3.x.patch
+++ b/patches/MAGETWO-PAYMENT-BOOSTER_2.3.x.patch
@@ -1,0 +1,13 @@
+diff --git a/app/code/Bold/CheckoutPaymentBooster/etc/csp_whitelist.xml b/etc/csp_whitelist.xml
+--- a/app/code/Bold/CheckoutPaymentBooster/etc/csp_whitelist.xml	(revision f940d81da5d45eb97f6bc377bf81a2e0a9d1ddab)
++++ b/app/code/Bold/CheckoutPaymentBooster/etc/csp_whitelist.xml	(date 1738941437008)
+@@ -34,7 +34,8 @@
+                 <value id="bold_local" type="host">*.bold.ninja</value>
+                 <value id="bold_applepay_script" type="host">*.cdn-apple.com</value>
+                 <value id="bold_stripe" type="host">*.stripe.com</value>
+-                <value id="bold_inline_script_hash" type="hash" algorithm="sha256">7nnKyr+RUZ9a44Hg3lYwjgkUx5VyFQwv2ZUhVw6N7J4=</value>
++                <value id="bold-google" type="host">https://www.google.com</value>
++                <value id="bold-gstatic" type="host">www.gstatic.com</value>
+             </values>
+         </policy>
+         <policy id="frame-src">


### PR DESCRIPTION
There are incompatible content security policies used in Adobe Commerce 2.3.x and Adobe Commerce 2.4.x, so we cannot have a single CSP whitelist for both versions.

1. Updated `csp_whitelist.xml` to be valid for 2.4.x
2. Added patch to make `csp_whitelist.xml` compatible with 2.3.x

Fixes [CHK-7629](https://boldapps.atlassian.net/browse/CHK-7629)

[CHK-7629]: https://boldapps.atlassian.net/browse/CHK-7629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ