### PR TITLE
CHK-7563: Fix wrong billing address for wallet pay buttons at payment step

### DIFF
--- a/view/frontend/web/js/action/express-pay/update-quote-braintree-action.js
+++ b/view/frontend/web/js/action/express-pay/update-quote-braintree-action.js
@@ -16,7 +16,7 @@ define(
          * @param {{}} paymentApprovalData
          * @return {void}
          */
-        return async function (paymentInformation, paymentApprovalData) {
+        return async function (paymentInformation, paymentApprovalData, isSpiContainer) {
             const paymentData = paymentApprovalData.payment_data;
             if (paymentData.email) {
                 quote.guestEmail = paymentData.email;
@@ -44,11 +44,19 @@ define(
                     paymentData.shipping_address['phone'] = paymentData.customer.phone;
                 }
             }
-            if (paymentData.shipping_address) {
-                updateQuoteAddressAction('shipping', paymentData.shipping_address);
-            }
-            if (paymentData.billing_address) {
-                updateQuoteAddressAction('billing', paymentData.billing_address);
+
+            if (isSpiContainer) {
+                if (paymentData.billing_address) {
+                    updateQuoteAddressAction('billing', paymentData.billing_address);
+                }
+            } else {
+                if (paymentData.shipping_address) {
+                    updateQuoteAddressAction('shipping', paymentData.shipping_address);
+                }
+
+                if (paymentData.billing_address) {
+                    updateQuoteAddressAction('billing', paymentData.billing_address);
+                }
             }
         };
     }

--- a/view/frontend/web/js/action/express-pay/update-quote-ppcp-action.js
+++ b/view/frontend/web/js/action/express-pay/update-quote-ppcp-action.js
@@ -24,7 +24,8 @@ define(
          *
          * @return {Promise}
          */
-        return async function (paymentApprovalData) {
+
+        return async function (paymentApprovalData, isSpiContainer) {
             let order;
             try {
                 order = await getExpressPayOrderAction(
@@ -56,11 +57,15 @@ define(
                 return address;
             }
 
-            quote.guestEmail = order.email;
-            updateQuoteAddressAction('billing', _convertAddress(order.billing_address, order));
+            if (isSpiContainer) {
+                updateQuoteAddressAction('billing', _convertAddress(order.billing_address, order));
+            } else {
+                quote.guestEmail = order.email;
+                updateQuoteAddressAction('billing', _convertAddress(order.billing_address, order));
 
-            if (paymentApprovalData.shipping_strategy === 'dynamic') {
-                updateQuoteAddressAction('shipping', _convertAddress(order.shipping_address, order));
+                if (paymentApprovalData.shipping_strategy === 'dynamic') {
+                    updateQuoteAddressAction('shipping', _convertAddress(order.shipping_address, order));
+                }
             }
         };
     }

--- a/view/frontend/web/js/action/express-pay/update-quote-wallet-pay-action.js
+++ b/view/frontend/web/js/action/express-pay/update-quote-wallet-pay-action.js
@@ -14,33 +14,39 @@ define(
          *
          * @return {Promise}
          */
-        return async function (paymentApprovalData) {
+        return async function (paymentApprovalData, isSpiContainer) {
             const paymentData = paymentApprovalData['payment_data'];
             const shippingAddress = paymentData['shipping_address'];
             const billingAddress = paymentData['billing_address'];
 
-            let email;
-            if (shippingAddress && shippingAddress['emailAddress']) { // Apple Pay
-                email = shippingAddress['emailAddress'];
-            } else if (paymentData['email']) { // Braintree Google Pay
-                email = paymentData['email'];
-            } else if (paymentData['customer'] && paymentData['customer']['email_address']) { // PPCP Google Pay
-                email = paymentData['customer']['email_address'];
-            }
-
-            if (email) {
-                if (shippingAddress) {
-                    shippingAddress.email = email;
+            if (isSpiContainer) {
+                if (billingAddress) {
+                    updateQuoteAddressAction('billing', billingAddress);
+                }
+            } else {
+                let email;
+                if (shippingAddress && shippingAddress['emailAddress']) { // Apple Pay
+                    email = shippingAddress['emailAddress'];
+                } else if (paymentData['email']) { // Braintree Google Pay
+                    email = paymentData['email'];
+                } else if (paymentData['customer'] && paymentData['customer']['email_address']) { // PPCP Google Pay
+                    email = paymentData['customer']['email_address'];
                 }
 
-                billingAddress.email = email;
-                quote.guestEmail = email;
-            }
+                if (email) {
+                    if (shippingAddress) {
+                        shippingAddress.email = email;
+                    }
 
-            if (shippingAddress) {
-                updateQuoteAddressAction('shipping', shippingAddress);
+                    billingAddress.email = email;
+                    quote.guestEmail = email;
+                }
+
+                if (shippingAddress) {
+                    updateQuoteAddressAction('shipping', shippingAddress);
+                }
+                updateQuoteAddressAction('billing', billingAddress);
             }
-            updateQuoteAddressAction('billing', billingAddress);
         };
     }
 );

--- a/view/frontend/web/js/model/spi/callbacks/on-approve-payment-order-callback.js
+++ b/view/frontend/web/js/model/spi/callbacks/on-approve-payment-order-callback.js
@@ -54,15 +54,15 @@ define(
                 };
             }
 
-            if (!isSpiContainer) {
-                if (isWalletPayment) {
-                    await updateQuoteWalletPayAction(paymentApprovalData);
-                } else if (paymentType === 'ppcp') {
-                    await updateQuotePPCPAction(paymentApprovalData);
-                } else {
-                    await updateQuoteBraintreeAction(paymentInformation, paymentApprovalData);
-                }
+            if (isWalletPayment) {
+                await updateQuoteWalletPayAction(paymentApprovalData, isSpiContainer);
+            } else if (paymentType === 'ppcp') {
+                await updateQuotePPCPAction(paymentApprovalData, isSpiContainer);
+            } else {
+                await updateQuoteBraintreeAction(paymentInformation, paymentApprovalData, isSpiContainer);
+            }
 
+            if (!isSpiContainer) {
                 try {
                     await saveShippingInformationAction(true);
                 } catch (error) {


### PR DESCRIPTION
Currently, for the wallet payment buttons at the payment step, we use both the shipping and billing addresses from Magento. With this change, the shipping address will continue from Magento, while the billing address will now be retrieved from the respective PayPal/Google/Apple Pay model.

Fixes [CHK-7563](https://boldapps.atlassian.net/browse/CHK-7563)

[CHK-7563]: https://boldapps.atlassian.net/browse/CHK-7563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ