### PR TITLE
CHK-7315 - fix Express Pay multiple authorizations when ReCaptcha fails

### DIFF
--- a/Plugin/ReCaptcha/DisableRecaptchaForExpressPayPlugin.php
+++ b/Plugin/ReCaptcha/DisableRecaptchaForExpressPayPlugin.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\CheckoutPaymentBooster\Plugin\ReCaptcha\Model;
+
+use Magento\Framework\App\Request\DataPersistorInterface;
+use Magento\ReCaptchaUi\Model\IsCaptchaEnabledInterface;
+use Magento\ReCaptchaValidationApi\Api\Data\ValidationConfigInterface;
+use Magento\ReCaptchaWebapiApi\Api\Data\EndpointInterface;
+use Magento\ReCaptchaCheckout\Model\WebapiConfigProvider;
+use Psr\Log\LoggerInterface;
+
+class DisableRecaptchaForExpressPayPlugin
+{
+    private const PLACE_ORDER_CAPTCHA_ID = 'place_order';
+
+    /**
+     * @var IsCaptchaEnabledInterface $isEnabled
+     */
+    private $isEnabled;
+
+    /**
+     * @var DataPersistorInterface
+     */
+    private $dataPersistor;
+
+    /**
+     * @var LoggerInterface $logger
+     */
+    private $logger;
+
+    /**
+     * @param IsCaptchaEnabledInterface $isEnabled
+     * @param DataPersistorInterface $dataPersistor
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        IsCaptchaEnabledInterface $isEnabled,
+        DataPersistorInterface $dataPersistor,
+        LoggerInterface $logger,
+    ) {
+        $this->isEnabled = $isEnabled;
+        $this->dataPersistor = $dataPersistor;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @param WebapiConfigProvider $subject
+     * @param \Closure $proceed
+     * @param EndpointInterface $endpoint
+     * @return ValidationConfigInterface|null
+     * @throws \Magento\Framework\Exception\InputException
+     */
+    public function aroundGetConfigFor(WebapiConfigProvider $subject, \Closure $proceed, EndpointInterface $endpoint): ?ValidationConfigInterface
+    {
+        if ($endpoint->getServiceMethod() === 'savePaymentInformationAndPlaceOrder'
+            || $endpoint->getServiceClass() === 'Magento\QuoteGraphQl\Model\Resolver\SetPaymentAndPlaceOrder'
+            || $endpoint->getServiceClass() === 'Magento\QuoteGraphQl\Model\Resolver\PlaceOrder'
+        ) {
+            if ($this->isEnabled->isCaptchaEnabledFor(self::PLACE_ORDER_CAPTCHA_ID)) {
+                $skipRecaptcha = $this->dataPersistor->get('skip_recaptcha');
+                $this->dataPersistor->clear('skip_recaptcha');
+                if ($skipRecaptcha) {
+                    return null;
+                }
+            }
+        }
+
+        return $proceed($endpoint);
+    }
+}

--- a/Service/ExpressPay/Callback/OnApprove.php
+++ b/Service/ExpressPay/Callback/OnApprove.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\CheckoutPaymentBooster\Service\ExpressPay\Callback;
+
+use Magento\Checkout\Model\Session;
+use Magento\Framework\App\Request\DataPersistorInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Session\SessionManagerInterface;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Model\MaskedQuoteIdToQuoteIdInterface;
+use Magento\Quote\Model\Quote;
+use Psr\Log\LoggerInterface;
+
+class OnApprove
+{
+    /**
+     * @var MaskedQuoteIdToQuoteIdInterface $maskedQuoteIdToQuoteId
+     */
+    private $maskedQuoteIdToQuoteId;
+
+    /**
+     * @var SessionManagerInterface
+     */
+    private $checkoutSession;
+
+    /**
+     * @var CartRepositoryInterface
+     */
+    private $cartRepository;
+
+    /**
+     * @var DataPersistorInterface
+     */
+    private $dataPersistor;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+
+    public function __construct(
+        MaskedQuoteIdToQuoteIdInterface $maskedQuoteIdToQuoteId,
+        SessionManagerInterface         $checkoutSession,
+        CartRepositoryInterface         $cartRepository,
+        DataPersistorInterface          $dataPersistor,
+        LoggerInterface                 $logger,
+    ) {
+        $this->maskedQuoteIdToQuoteId = $maskedQuoteIdToQuoteId;
+        $this->checkoutSession = $checkoutSession;
+        $this->cartRepository = $cartRepository;
+        $this->dataPersistor = $dataPersistor;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @param string|int $quoteMaskId
+     * @param string $gatewayId
+     * @param string $paypalOrderId
+     * @return void
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function execute($quoteMaskId, $gatewayId, $paypalOrderId): void
+    {
+        if (!is_numeric($quoteMaskId) && strlen($quoteMaskId) === 32) {
+            try {
+                $quoteId = $this->maskedQuoteIdToQuoteId->execute($quoteMaskId);
+            } catch (NoSuchEntityException $noSuchEntityException) {
+                throw new LocalizedException(
+                    __('Active quote not found. Invalid quote mask ID "%1".', $quoteMaskId)
+                );
+            }
+        } else {
+            $quoteId = $quoteMaskId;
+        }
+
+        if ($quoteId !== '') {
+            try {
+                /** @var Quote $quote */
+                $quote = $this->cartRepository->get((int)$quoteId);
+            } catch (NoSuchEntityException $noSuchEntityException) {
+                throw new LocalizedException(__('Active quote not found. Invalid quote ID "%1".', $quoteId));
+            }
+        } else {
+            try {
+                /** @var Session $session */
+                $session = $this->checkoutSession;
+                /** @var Quote $quote */
+                $quote = $session->getQuote();
+            } catch (NoSuchEntityException $noSuchEntityException) {
+                throw new LocalizedException(__('Active quote not found.'));
+            }
+        }
+
+        $this->dataPersistor->set('skip_recaptcha', true);
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -23,6 +23,9 @@
     <type name="Magento\Quote\Model\QuoteManagement">
         <plugin name="disable_bold_address_validation" type="Bold\CheckoutPaymentBooster\Plugin\Quote\Model\QuoteManagement\DisableBoldAddressValidationPlugin" />
     </type>
+    <type name="Magento\ReCaptchaCheckout\Model\WebapiConfigProvider">
+        <plugin name="DisableReCaptchaForExpressPay" type="Bold\CheckoutPaymentBooster\Plugin\ReCaptcha\Model\DisableRecaptchaForExpressPayPlugin" />
+    </type>
     <type name="Bold\CheckoutPaymentBooster\Model\Http\Client\RequestsLogger">
         <arguments>
             <argument name="logger" xsi:type="object">Bold\CheckoutPaymentBooster\Model\Http\Client\RequestsLogger\Logger</argument>
@@ -173,6 +176,12 @@
     <type name="Bold\CheckoutPaymentBooster\Service\ExpressPay\Order\Get">
         <arguments>
             <argument name="httpClient" xsi:type="object">Bold\CheckoutPaymentBooster\Model\Http\BoldClient</argument>
+        </arguments>
+    </type>
+
+    <type name="Bold\CheckoutPaymentBooster\Service\ExpressPay\Callback\OnApprove">
+        <arguments>
+            <argument name="checkoutSession" xsi:type="object">Magento\Checkout\Model\Session\Proxy</argument>
         </arguments>
     </type>
 

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -45,6 +45,21 @@
             <parameter name="quoteMaskId" force="true">%quote_mask_id%</parameter>
         </data>
     </route>
+    <route url="/V1/express_pay/callback/on_approve" method="POST">
+        <service class="Bold\CheckoutPaymentBooster\Service\ExpressPay\Callback\OnApprove" method="execute" />
+        <resources>
+            <resource ref="anonymous" />
+        </resources>
+    </route>
+    <route url="/V1/express_pay/callback/mine/on_approve" method="POST">
+        <service class="Bold\CheckoutPaymentBooster\Service\ExpressPay\Callback\OnApprove" method="execute" />
+        <resources>
+            <resource ref="self" />
+        </resources>
+        <data>
+            <parameter name="quoteMaskId" force="true">%quote_mask_id%</parameter>
+        </data>
+    </route>
     <route url="/V1/shops/:shopId/guest-cart/:cartId/hydrate/:publicOrderId" method="PUT">
         <service class="Bold\CheckoutPaymentBooster\Api\Order\GuestHydrateOrderInterface" method="hydrate"/>
         <resources>

--- a/view/frontend/web/js/action/express-pay/on-approve-express-pay-order-action.js
+++ b/view/frontend/web/js/action/express-pay/on-approve-express-pay-order-action.js
@@ -1,0 +1,26 @@
+define(
+    [
+        'Bold_CheckoutPaymentBooster/js/model/platform-client'
+    ],
+    function (
+        platformClient
+    ) {
+        'use strict';
+
+        /**
+         * Get Express Pay order
+         *
+         * @param {{}}
+         * @returns {Promise}
+         */
+        return function (paymentApprovalData) {
+            return platformClient.post('rest/V1/express_pay/callback/on_approve',
+                {
+                    quoteMaskId: window.checkoutConfig.quoteData.entity_id,
+                    gatewayId: paymentApprovalData.gateway_id,
+                    paypalOrderId: paymentApprovalData?.payment_data.order_id ?? paymentApprovalData.order_id
+                }
+            );
+        };
+    }
+);

--- a/view/frontend/web/js/model/spi/callbacks/on-approve-payment-order-callback.js
+++ b/view/frontend/web/js/model/spi/callbacks/on-approve-payment-order-callback.js
@@ -9,6 +9,7 @@ define(
         'Bold_CheckoutPaymentBooster/js/action/express-pay/update-quote-ppcp-action',
         'Bold_CheckoutPaymentBooster/js/action/express-pay/update-quote-braintree-action',
         'Bold_CheckoutPaymentBooster/js/action/express-pay/save-shipping-information-action',
+        'Bold_CheckoutPaymentBooster/js/action/express-pay/on-approve-express-pay-order-action',
         'Magento_Ui/js/model/messageList'
     ],
     function (
@@ -21,6 +22,7 @@ define(
         updateQuotePPCPAction,
         updateQuoteBraintreeAction,
         saveShippingInformationAction,
+        onApproveExpressPayOrderAction,
         messageList
     ) {
         'use strict';
@@ -67,6 +69,15 @@ define(
                     await saveShippingInformationAction(true);
                 } catch (error) {
                     console.error('Could not save shipping information for Express Pay order.', error);
+                    return;
+                }
+            }
+
+            if (paymentType === 'ppcp') {
+                try {
+                    await onApproveExpressPayOrderAction(paymentApprovalData);
+                } catch(error) {
+                    console.error('Error executing on approve callback hook for Express Pay order.', error);
                     return;
                 }
             }


### PR DESCRIPTION
Using Express Pay, with ReCaptcha enabled, the PayPal modal will complete prior to ReCaptcha executing on place order event. So we are observing an authorization in the customer's PPCP account for each time ReCaptcha failed.

We'll work around the problem for now by overriding the ReCaptcha when paying with the PayPal express pay modal. This solution was signed off by Product.

The PayPal `onApprove` callback is the very last action taken by this modal after payment is authorized. Ended up using the `DataPersistor` to store a flag. Seemed appropriate but I'm still new to Magento.