### PR TITLE
CHK-7256: Add Bold local env domain to style-src CSP whitelist

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -69,6 +69,7 @@
         </policy>
         <policy id="style-src">
             <values>
+                <value id="bold_internal" type="host">*.bold.ninja</value>
                 <value id="bold_eps_static" type="host">static-eps.secure.boldcommerce.com</value>
                 <value id="bold_staging_eps_static" type="host">static-eps.secure.staging.boldcommerce.com</value>
             </values>


### PR DESCRIPTION
While testing Front end logging with Bold Booster extension we noticed that the EPS styles were not allowed for local development environments.

![Screenshot 2025-02-19 at 12 07 52 PM](https://github.com/user-attachments/assets/1d512dc7-77b8-4759-92dd-c2a72befe983)

This add it to the allow list enabling local environments without the need to hardcode in CSP.

Relates to [CHK-7256](https://boldapps.atlassian.net/browse/CHK-7256)

[CHK-7256]: https://boldapps.atlassian.net/browse/CHK-7256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ