### PR TITLE
CHK-7891: Fix JavaScript Error Thrown When Using Apple Pay From Product Page

### DIFF
--- a/view/frontend/web/js/action/express-pay/get-required-order-data-action.js
+++ b/view/frontend/web/js/action/express-pay/get-required-order-data-action.js
@@ -85,19 +85,20 @@ define(
                         break;
                     case 'items':
                         let quoteItems = quote.getItems() ?? [];
+                        let requiredQuoteItems;
 
                         if ($('body').hasClass('catalog-product-view') && quoteItems.length === 0) {
-                            quoteItems = getProductItemData();
+                            requiredQuoteItems = getProductItemData();
                         }
 
                         if (quoteItems.length > 0) {
-                            quoteItems = quote.getItems().map(item => ({
+                            requiredQuoteItems = quoteItems.map(item => ({
                                 amount: parseInt(parseFloat(item.base_price) * 100),
                                 label: item.name
                             }));
                         }
 
-                        payload[requirement] = quoteItems;
+                        payload[requirement] = requiredQuoteItems;
 
                         break;
                     case 'billing_address':


### PR DESCRIPTION
Fixes “quote.getItems().map is not a function” JavaScript error thrown when placing an Apple Pay Digital Wallets order from the product detail page.

Fixes [CHK-7891](https://boldapps.atlassian.net/browse/CHK-7891)