### PR TITLE
CHK-7921: Resolve rounding issues

### DIFF
--- a/Service/ExpressPay/QuoteConverter.php
+++ b/Service/ExpressPay/QuoteConverter.php
@@ -246,7 +246,7 @@ class QuoteConverter
             'order_data' => [
                 'items' => array_map(
                     static function (CartItemInterface $cartItem) use ($currencyCode, $taxIncluded): array {
-                        $itemPrice = $taxIncluded ? $cartItem->getRowTotalInclTax() - $cartItem->getBaseTaxAmount() : $cartItem->getRowTotal();
+                        $itemPrice = $taxIncluded ? $cartItem->getRowTotalInclTax() - $cartItem->getTaxAmount() : $cartItem->getRowTotal();
 
                         return [
                             'name' => $cartItem->getName() ?? '',
@@ -280,7 +280,15 @@ class QuoteConverter
                         array_sum(
                             array_map(
                                 static function (CartItemInterface $cartItem) use ($taxIncluded) {
-                                    return $taxIncluded ? $cartItem->getRowTotalInclTax() - $cartItem->getBaseTaxAmount() : $cartItem->getRowTotal();
+                                    $itemPrice = $taxIncluded ? $cartItem->getRowTotalInclTax() - $cartItem->getTaxAmount() : $cartItem->getRowTotal();
+                                    $roundedItemPrice = number_format(
+                                        $itemPrice / $cartItem->getQty(),
+                                        2,
+                                        '.',
+                                        ''
+                                    );
+
+                                    return $roundedItemPrice * $cartItem->getQty();
                                 },
                                 $quoteItems
                             )


### PR DESCRIPTION
- Ensure item total is always equal to unit amount * qty.

When a merchant has `Catalog Prices` set to `Including Tax` - a quote items rowTotal is not always equal to an items unit price * qty.  Here is an example quote from Magento that demonstrates this:
```
        "items": [
            {
                "name": "Fusion Backpack",
                "sku": "24-MB02",
                "unit_amount": {
                    "currency_code": "USD",
                    "value": "106.56"
                },
                "quantity": 2,
                "is_shipping_required": true
            }
        ],
        "item_total": {
            "currency_code": "USD",
            "value": "213.11"
        },
        "amount": {
            "currency_code": "USD",
            "value": "213.00"
        },
        "tax_total": {
            "currency_code": "USD",
            "value": "37.51"
        },
        "discount": {
            "currency_code": "USD",
            "value": "52.00"
        }
    },
    "shipping_strategy": "dynamic"
}
```

Note, that the item price is 106.56. The items cost set in the merchants admin is 130, with a 22% tax rate:
130 / 1.22 = 106.557377

Magento rounds this to 106.56 on the quote - but calculates the row total without rounding:
106.557377 * 2 = 213.11

This case fails PayPal validation with the error:
```
UNPROCESSABLE_ENTITY - ITEM_TOTAL_MISMATCH:\/purchase_units\/@reference_id=='default'\/amount\/breakdown\/item_total\/value:Should equal sum of (unit_amount * quantity) across all items for a given purchase_unit
```

This PR ensures that the item total is always equal to the unit_amount * qty to pass PayPal validation.

PayPal also has validation that requires `amount` equals `item_total + tax_total + shipping - discount`, however EPS allows for and resolves a discrepancy of 0.1 in this case by adjusting either the tax, or discount amount.  Therefore, after this PR orders will go through successfully and customers will still be charged the correct amount.