### PR TITLE
CHK-6478 - Support for Multiple Payment Gateways

### DIFF
--- a/Model/CheckoutData.php
+++ b/Model/CheckoutData.php
@@ -171,13 +171,24 @@ class CheckoutData
     }
 
     /**
-     * Get EPS gateway ID from checkout session.
+     * Get Flow Payment Gateway ID from checkout session.
      *
      * @return int|null
      */
-    public function getEpsGatewayId(): ?int
+    public function getFlowPaymentGatewayId(): ?int
     {
         $checkoutData = $this->checkoutSession->getBoldCheckoutData();
         return $checkoutData['data']['flow_settings']['eps_gateway_id'] ?? null;
+    }
+
+    /**
+     * Get EPS payment gateways from checkout session.
+     *
+     * @return array
+     */
+    public function getPaymentGateways(): array
+    {
+        $checkoutData = $this->checkoutSession->getBoldCheckoutData();
+        return $checkoutData['data']['payment_gateways'] ?? [];
     }
 }

--- a/UI/PaymentBoosterConfigProvider.php
+++ b/UI/PaymentBoosterConfigProvider.php
@@ -132,11 +132,11 @@ class PaymentBoosterConfigProvider implements ConfigProviderInterface
         $publicOrderId = $this->checkoutData->getPublicOrderId();
         $jwtToken = $this->checkoutData->getJwtToken();
         $epsAuthToken = $this->checkoutData->getEpsAuthToken();
-        $epsGatewayId = $this->checkoutData->getEpsGatewayId();
+        $paymentGateways = $this->checkoutData->getPaymentGateways();
         $currency = $store->getCurrentCurrency()->getCode();
         $shopUrl = $store->getBaseUrl();
 
-        if ($jwtToken === null || $epsAuthToken === null || $epsGatewayId === null) {
+        if ($jwtToken === null || $epsAuthToken === null || $paymentGateways === []) {
             $errorMsgs = [];
             if ($jwtToken === null) {
                 $errorMsgs[] = '$jwtToken is null.';
@@ -146,8 +146,8 @@ class PaymentBoosterConfigProvider implements ConfigProviderInterface
                 $errorMsgs[] = '$epsAuthToken is null.';
             }
 
-            if ($epsGatewayId === null) {
-                $errorMsgs[] = '$epsGatewayId is null.';
+            if ($paymentGateways === []) {
+                $errorMsgs[] = '$paymentGateways is empty.';
             }
 
             $this->logger->critical('Error in PaymentBoosterConfigProvider->getConfig(): ' . implode(', ', $errorMsgs));
@@ -165,7 +165,7 @@ class PaymentBoosterConfigProvider implements ConfigProviderInterface
                 'configurationGroupLabel' => $configurationGroupLabel,
                 'epsUrl' => $this->config->getEpsUrl($websiteId),
                 'epsStaticUrl' => $this->config->getStaticEpsUrl($websiteId),
-                'gatewayId' => $epsGatewayId,
+                'payment_gateways' => $paymentGateways,
                 'jwtToken' => $jwtToken,
                 'url' => $this->getBoldStorefrontUrl($websiteId, $publicOrderId),
                 'shopId' => $shopId,

--- a/view/frontend/web/js/action/express-pay/update-wallet-pay-order-action.js
+++ b/view/frontend/web/js/action/express-pay/update-wallet-pay-order-action.js
@@ -10,17 +10,17 @@ define(
         /**
          * Update Wallet Pay order.
          *
-         * @param {string} orderId
+         * @param {Object} paymentPayload
          * @return {Promise}
          */
-        return async function (orderId) {
+        return async function (paymentPayload) {
             // todo: should be put instead of post method.
             return platformClient.post(
                 'rest/V1/express_pay/order/update',
                 {
                     quoteMaskId: window.checkoutConfig.quoteData.entity_id,
-                    gatewayId: window.checkoutConfig.bold.gatewayId,
-                    paypalOrderId: orderId
+                    gatewayId: paymentPayload.gateway_id,
+                    paypalOrderId: paymentPayload.payment_data.order_id,
                 }
             );
         };

--- a/view/frontend/web/js/action/fastlane/eps-tokenize-action.js
+++ b/view/frontend/web/js/action/fastlane/eps-tokenize-action.js
@@ -13,7 +13,7 @@ define(
          * Tokenize EPS.
          */
         return async function (tokenId) {
-            if (!window.checkoutConfig.bold.epsAuthToken || !window.checkoutConfig.bold.gatewayId) {
+            if (!window.checkoutConfig.bold.epsAuthToken || !window.checkoutConfig.bold.flowPaymentGatewayId) {
                 return;
             }
 
@@ -21,7 +21,7 @@ define(
             const body = {
                 'version': 1,
                 'auth_token': window.checkoutConfig.bold.epsAuthToken,
-                'gateway_id': Number(window.checkoutConfig.bold.gatewayId),
+                'gateway_id': Number(window.checkoutConfig.bold.flowPaymentGatewayId),
                 'tender_type': 'credit_card',
                 'currency': quote.totals()['base_currency_code'],
                 'payload_type': 'card_token',

--- a/view/frontend/web/js/model/fastlane.js
+++ b/view/frontend/web/js/model/fastlane.js
@@ -63,7 +63,7 @@ define([
             try {
                 if (!this.gatewayData) {
                     boldPaymentsInstance.state = {options: {fastlane: this.isAvailable()}};
-                    this.gatewayData = (await boldPaymentsInstance.getFastlaneClientInit())[window.checkoutConfig.bold.gatewayId] || null;
+                    this.gatewayData = (await boldPaymentsInstance.getFastlaneClientInit())[window.checkoutConfig.bold.flowPaymentGatewayId] || null;
                 }
                 if (!this.gatewayData) {
                     window.boldFastlaneInstanceCreateInProgress = false;

--- a/view/frontend/web/js/model/spi.js
+++ b/view/frontend/web/js/model/spi.js
@@ -113,13 +113,11 @@ define([
                 'eps_bucket_url': window.checkoutConfig.bold.epsStaticUrl,
                 'group_label': window.checkoutConfig.bold.configurationGroupLabel,
                 'trace_id': window.checkoutConfig.bold.publicOrderId,
-                'payment_gateways': [
-                    {
-                        'gateway_id': Number(window.checkoutConfig.bold.gatewayId),
-                        'auth_token': window.checkoutConfig.bold.epsAuthToken,
-                        'currency': window.checkoutConfig.bold.currency,
-                    }
-                ],
+                'payment_gateways': window.checkoutConfig.bold.payment_gateways.map(gw => ({
+                    gateway_id: gw.id,
+                    auth_token: gw.auth_token,
+                    currency: gw.currency,
+                })),
                 'callbacks': {
                     'onClickPaymentOrder': async (paymentType, paymentPayload) => {
                         isProductPageActive = paymentPayload.containerId.includes('product-detail');
@@ -212,8 +210,10 @@ define([
             const paymentsInstance = new window.bold.Payments(initialData);
             window.boldFastlaneInstance = await fastlane.getFastlaneInstance(paymentsInstance);
             await paymentsInstance.initialize;
-            if (paymentsInstance.paymentGateways[0]?.type === 'braintree') {
-                await this._loadBraintreeScripts(paymentsInstance); //todo: remove as soon as payments.js is adapted to use requirejs
+
+            const braintreeGateway = paymentsInstance.paymentGateways?.find((gw) => gw.type === 'braintree');
+            if (braintreeGateway) {
+                await this._loadBraintreeScripts(paymentsInstance, braintreeGateway); //todo: remove as soon as payments.js is adapted to use requirejs
             }
             window.boldPaymentsInstance = paymentsInstance;
             window.createBoldPaymentsInstanceInProgress = false;
@@ -237,21 +237,22 @@ define([
          * @return {Promise<void>}
          * @private
          */
-        _loadBraintreeScripts: async function (paymentsInstance) {
+        _loadBraintreeScripts: async function (paymentsInstance, braintreeGateway) {
             await loadScriptAction('bold_braintree_client', 'braintree.client');
             await loadScriptAction('bold_braintree_data_collector', 'braintree.dataCollector');
-            const gatewayData = paymentsInstance.paymentGateways[0].credentials || null;
-            if (!gatewayData) {
+
+            const gatewayServices = braintreeGateway.gateway_services;
+            if (!gatewayServices) {
                 return;
             }
-            if (gatewayData.is_paypal_enabled) {
+            if (gatewayServices.paypal) {
                 await loadScriptAction('bold_braintree_paypal_checkout', 'braintree.paypalCheckout');
             }
-            if (gatewayData.is_google_pay_enabled) {
+            if (gatewayServices.google_pay) {
                 await loadScriptAction('bold_braintree_google_payment', 'braintree.googlePayment');
                 await loadScriptAction('bold_google_pay');
             }
-            if (gatewayData.is_apple_pay_enabled) {
+            if (gatewayServices.apple_pay) {
                 await loadScriptAction('bold_apple_pay', 'braintree.applePay');
             }
         },

--- a/view/frontend/web/js/model/spi/callbacks/on-update-payment-order-callback.js
+++ b/view/frontend/web/js/model/spi/callbacks/on-update-payment-order-callback.js
@@ -34,7 +34,7 @@ define(
             await updateQuoteShippingMethodAction(paymentData['shipping_options']);
 
             if (paymentType === 'ppcp' && !isWalletPayment) {
-                await updateWalletPayOrderAction(paymentData['order_id']);
+                await updateWalletPayOrderAction(paymentPayload);
             }
 
             return getRequiredOrderDataAction(

--- a/view/frontend/web/js/view/payment/method-renderer/bold-wallet-payments.js
+++ b/view/frontend/web/js/view/payment/method-renderer/bold-wallet-payments.js
@@ -51,9 +51,16 @@ define(
             renderPaymentsButtons: async function () {
                 this.isWalletPayLoading(true);
                 const boldPaymentsInstance = await spi.getPaymentsClient();
-                const gatewayData = boldPaymentsInstance.paymentGateways[0] || null;
-                const isBraintreeWalletPayments = gatewayData.type === 'braintree' && (gatewayData.credentials.is_paypal_enabled || gatewayData.credentials.is_google_pay_enabled || gatewayData.credentials.is_paypal_enabled);
-                const isPaymentsButtonsVisible = gatewayData && (gatewayData.type === 'ppcp' || isBraintreeWalletPayments);
+
+                const isPaymentsButtonsVisible = boldPaymentsInstance.paymentGateways?.some(gw => {
+                    return gw.gateway_services.paypal
+                        || gw.gateway_services.paylater
+                        || gw.gateway_services.venmo
+                        || gw.gateway_services.google_pay
+                        || gw.gateway_services.apple_pay
+                        || gw.gateway_services.standard_payments
+                });
+
                 if (isPaymentsButtonsVisible) {
                     const walletPaymentOptions = {
                         shopName: window.checkoutConfig.bold?.shopName ?? '',


### PR DESCRIPTION
Adds support for multiple payment gateways saved in the Checkout Admin.

For example here we've rendered both PPCP (digital wallets) and Authorize.net (the credit card form).
<img width="903" alt="Screenshot 2025-02-25 at 4 34 15 PM" src="https://github.com/user-attachments/assets/3413a19d-9a96-4ff2-a351-1755d4fe2106" />
<img width="903" alt="Screenshot 2025-02-25 at 4 34 03 PM" src="https://github.com/user-attachments/assets/ac80e129-635b-4683-9d30-13ac9859ce08" />

Validation in Checkout Admin will ensure only one `paypal` service type is added at a time.