### PR TITLE
CHK-7721 - add public_order_id to PayPal create order request

### DIFF
--- a/Service/ExpressPay/Order/Create.php
+++ b/Service/ExpressPay/Order/Create.php
@@ -32,7 +32,7 @@ class Create
      * @var MaskedQuoteIdToQuoteIdInterface
      */
     private $maskedQuoteIdToQuoteId;
-    
+
     /**
      * @var CartRepositoryInterface
      */
@@ -69,13 +69,14 @@ class Create
 
     /**
      * @param string|int $quoteMaskId
+     * @param string $publicOrderId
      * @param string $gatewayId
      * @param string $shippingStrategy
      * @return array
      * @phpstan-return array{order_id: string}
      * @throws \Magento\Framework\Exception\LocalizedException
      */
-    public function execute($quoteMaskId, $gatewayId, $shippingStrategy): array
+    public function execute($quoteMaskId, $publicOrderId, $gatewayId, $shippingStrategy): array
     {
         if (!is_numeric($quoteMaskId) && strlen($quoteMaskId) === 32) {
             try {
@@ -118,6 +119,7 @@ class Create
 
         $expressPayData = $this->quoteConverter->convertFullQuote($quote, $gatewayId);
         $expressPayData['shipping_strategy'] = $shippingStrategy;
+        $expressPayData['public_order_id'] = $publicOrderId;
 
         try {
             $result = $this->httpClient->post($websiteId, $uri, $expressPayData);

--- a/Test/Integration/Service/ExpressPay/Order/CreateTest.php
+++ b/Test/Integration/Service/ExpressPay/Order/CreateTest.php
@@ -70,6 +70,7 @@ class CreateTest extends TestCase
         ];
         $actualResultData = $createExpressPayOrderService->execute(
             $quoteMaskId,
+            'ff152513-f548-11ef-b987-3a475e3f6277',
             'e4403e69-1fd2-4d8a-be28-fdbf911a20bb',
             'dynamic'
         );
@@ -91,6 +92,7 @@ class CreateTest extends TestCase
 
         $createExpressPayOrderService->execute(
             'bb567af9f9d44983971981a6e8eacfd6',
+            'ff152513-f548-11ef-b987-3a475e3f6277',
             '525f40b7-c512-4e5b-aa82-cc7276a48de9',
             'dynamic'
         );
@@ -106,7 +108,11 @@ class CreateTest extends TestCase
         /** @var Create $createExpressPayOrderService */
         $createExpressPayOrderService = $objectManager->create(Create::class);
 
-        $createExpressPayOrderService->execute(42, '525f40b7-c512-4e5b-aa82-cc7276a48de9', 'dynamic');
+        $createExpressPayOrderService->execute(42,
+            'ff152513-f548-11ef-b987-3a475e3f6277',
+            '525f40b7-c512-4e5b-aa82-cc7276a48de9',
+            'dynamic'
+        );
     }
 
     /**
@@ -132,7 +138,12 @@ class CreateTest extends TestCase
         $boldClientMock->method('post')
             ->willThrowException(new Exception('HTTP 503 Service Unavailable'));
 
-        $createExpressPayOrderService->execute($quoteMaskId, 'ae066eda-f88a-4c13-938f-e8bd4e496144', 'dynamic');
+        $createExpressPayOrderService->execute(
+            $quoteMaskId,
+            'ff152513-f548-11ef-b987-3a475e3f6277',
+            'ae066eda-f88a-4c13-938f-e8bd4e496144',
+            'dynamic'
+        );
     }
 
     /**
@@ -165,7 +176,12 @@ class CreateTest extends TestCase
         $boldClientMock->method('post')
             ->willReturn($boldApiResultMock);
 
-        $createExpressPayOrderService->execute($quoteMaskId, 'ae066eda-f88a-4c13-938f-e8bd4e496144', 'dynamic');
+        $createExpressPayOrderService->execute(
+            $quoteMaskId,
+            'ff152513-f548-11ef-b987-3a475e3f6277',
+            'ae066eda-f88a-4c13-938f-e8bd4e496144',
+            'dynamic'
+        );
     }
 
     /**
@@ -197,7 +213,12 @@ class CreateTest extends TestCase
         $boldClientMock->method('post')
             ->willReturn($boldApiResultMock);
 
-        $createExpressPayOrderService->execute($quoteMaskId, '182011ba-9d43-47b7-9b74-8c234531ce20', 'dynamic');
+        $createExpressPayOrderService->execute(
+            $quoteMaskId,
+            'ff152513-f548-11ef-b987-3a475e3f6277',
+            '182011ba-9d43-47b7-9b74-8c234531ce20',
+            'dynamic'
+        );
     }
 
     /**

--- a/view/frontend/web/js/action/express-pay/create-wallet-pay-order-action.js
+++ b/view/frontend/web/js/action/express-pay/create-wallet-pay-order-action.js
@@ -18,6 +18,7 @@ define(
                 'rest/V1/express_pay/order/create',
                 {
                     quoteMaskId: window.checkoutConfig.quoteData.entity_id,
+                    publicOrderId: window.checkoutConfig.bold.publicOrderId,
                     gatewayId: paymentPayload.gateway_id,
                     shippingStrategy: paymentPayload.shipping_strategy || 'dynamic'
                 }


### PR DESCRIPTION
Adds the `public_order_id` to the PayPal create order request, to allow for easy association between `paypalDebugId` and orders. See the specification here
https://github.com/bold-commerce/engineering-specs/pull/177/files

Resolves [CHK-7721](https://boldapps.atlassian.net/browse/CHK-7721)

[CHK-7721]: https://boldapps.atlassian.net/browse/CHK-7721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ