### PR TITLE
CHK-8013: Fix Digital Wallets Errors Thrown in Mini Cart on Product Detail Page

### DIFF
--- a/view/frontend/templates/express-pay-product.phtml
+++ b/view/frontend/templates/express-pay-product.phtml
@@ -7,6 +7,15 @@ declare(strict_types=1);
     <div id="express-pay-buttons-product-details"></div>
 </div>
 
+<script>
+    if (!window.hasOwnProperty('checkoutConfig')) {
+        window.checkoutConfig = {
+            quoteData: {
+            },
+        };
+    }
+</script>
+
 <script type="text/x-magento-init">
     {
         "#express-pay-container-product": {

--- a/view/frontend/web/js/express-pay-storefront.js
+++ b/view/frontend/web/js/express-pay-storefront.js
@@ -26,7 +26,12 @@ define([
         },
 
         _getCheckoutConfig: async function () {
-            if (window.checkoutConfig) {
+            if (
+                window.hasOwnProperty('checkoutConfig')
+                && window.checkoutConfig.hasOwnProperty('quoteData')
+                && window.checkoutConfig.quoteData.hasOwnProperty('entity_id')
+                && window.checkoutConfig.quoteData.entity_id !== ''
+            ) {
                 return;
             }
             if (window.initExpressCheckoutInProcess) {
@@ -46,7 +51,20 @@ define([
                 dataType: 'json',
                 async: false,
                 success: function (checkoutConfig) {
-                    window.checkoutConfig = checkoutConfig;
+                    /* Set values at property level instead of overwriting entire object to preserve its reference in
+                       memory. */
+                    if (checkoutConfig.hasOwnProperty('quoteData')) {
+                        Object.keys(checkoutConfig.quoteData).forEach(key => {
+                            window.checkoutConfig.quoteData[key] = checkoutConfig.quoteData[key];
+                        });
+
+                        delete checkoutConfig.quoteData;
+                    }
+
+                    Object.keys(checkoutConfig).forEach(function (key) {
+                        window.checkoutConfig[key] = checkoutConfig[key];
+                    });
+
                     window.initExpressCheckoutInProcess = false;
                 },
                 fail: function () {


### PR DESCRIPTION
Fixes errors thrown when placing a Digital Wallets order from the mini cart on the product detail page after adding a product to the cart. These errors were caused by missing quote data.

Fixes [CHK-8013](https://boldapps.atlassian.net/browse/CHK-8013)