### PR TITLE
CHK-7953: Fix Errors for Authenticated Customers When Paying via Digital Wallets

### DIFF
--- a/Observer/ShortcutButtons/AddExpressPayButtonsObserver.php
+++ b/Observer/ShortcutButtons/AddExpressPayButtonsObserver.php
@@ -8,6 +8,8 @@ use Bold\CheckoutPaymentBooster\Block\ShortcutButtons\ExpressPayShortcutButtonsC
 use Bold\CheckoutPaymentBooster\Block\ShortcutButtons\ExpressPayShortcutButtonsMiniCart;
 use Bold\CheckoutPaymentBooster\Block\ShortcutButtons\ExpressPayShortcutButtonsProduct;
 use Bold\CheckoutPaymentBooster\Model\Config;
+use Bold\CheckoutPaymentBooster\ViewModel\ExpressPay as ExpressPayViewModel;
+use Bold\CheckoutPaymentBooster\ViewModel\ExpressPayFactory as ExpressPayViewModelFactory;
 use Magento\Catalog\Block\ShortcutButtons;
 use Magento\Framework\Event;
 use Magento\Framework\Event\Observer;
@@ -28,17 +30,27 @@ class AddExpressPayButtonsObserver implements ObserverInterface
     private $config;
 
     /**
+     * @var ExpressPayViewModelFactory
+     */
+    private $expressPayViewModelFactory;
+
+    /**
      * @var StoreManagerInterface
      */
     private $storeManager;
 
     /**
      * @param StoreManagerInterface $storeManager
+     * @param ExpressPayViewModelFactory $expressPayViewModelFactory
      * @param Config $config
      */
-    public function __construct(StoreManagerInterface $storeManager, Config $config)
-    {
+    public function __construct(
+        StoreManagerInterface $storeManager,
+        ExpressPayViewModelFactory $expressPayViewModelFactory,
+        Config $config
+    ) {
         $this->storeManager = $storeManager;
+        $this->expressPayViewModelFactory = $expressPayViewModelFactory;
         $this->config = $config;
     }
 
@@ -75,9 +87,16 @@ class AddExpressPayButtonsObserver implements ObserverInterface
         LayoutInterface $layout,
         ShortcutButtons $container
     ) {
+        /** @var ExpressPayViewModel $expressPayViewModel */
+        $expressPayViewModel = $this->expressPayViewModelFactory->create();
         $shortCut = $layout->createBlock(
             ExpressPayShortcutButtonsProduct::class,
-            ExpressPayShortcutButtonsProduct::NAME
+            ExpressPayShortcutButtonsProduct::NAME,
+            [
+                'data' => [
+                    'express_pay_view_model' => $expressPayViewModel,
+                ]
+            ]
         );
         $container->addShortcut($shortCut);
     }
@@ -106,9 +125,16 @@ class AddExpressPayButtonsObserver implements ObserverInterface
      */
     private function addMiniCartShortcut(LayoutInterface $layout, ShortcutButtons $container)
     {
+        /** @var ExpressPayViewModel $expressPayViewModel */
+        $expressPayViewModel = $this->expressPayViewModelFactory->create();
         $miniCartShortcut = $layout->createBlock(
             ExpressPayShortcutButtonsMiniCart::class,
-            ExpressPayShortcutButtonsMiniCart::NAME
+            ExpressPayShortcutButtonsMiniCart::NAME,
+            [
+                'data' => [
+                    'express_pay_view_model' => $expressPayViewModel,
+                ]
+            ]
         );
         $container->addShortcut($miniCartShortcut);
     }

--- a/ViewModel/ExpressPay.php
+++ b/ViewModel/ExpressPay.php
@@ -8,6 +8,14 @@ use Bold\CheckoutPaymentBooster\Model\CheckoutData;
 use Exception;
 use Magento\Checkout\Model\CompositeConfigProvider;
 use Magento\Checkout\Model\Session;
+use Magento\Customer\Api\CustomerRepositoryInterface;
+use Magento\Customer\Api\Data\CustomerInterface;
+use Magento\Customer\Model\Address\CustomerAddressDataProvider;
+use Magento\Customer\Model\Context as CustomerContext;
+use Magento\Customer\Model\Data\Customer;
+use Magento\Framework\App\Http\Context as HttpContext;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\View\Element\Block\ArgumentInterface;
 use Psr\Log\LoggerInterface;
 
@@ -34,21 +42,44 @@ class ExpressPay implements ArgumentInterface
     private $logger;
 
     /**
+     * @var HttpContext
+     */
+    private $httpContext;
+
+    /**
+     * @var CustomerRepositoryInterface
+     */
+    private $customerRepository;
+    /**
+     * @var CustomerAddressDataProvider
+     */
+    private $customerAddressDataProvider;
+
+    /**
      * @param CompositeConfigProvider $configProvider
      * @param Session $checkoutSession
      * @param CheckoutData $checkoutData
      * @param LoggerInterface $logger
+     * @param HttpContext $httpContext
+     * @param CustomerRepositoryInterface $customerRepository
+     * @param CustomerAddressDataProvider $customerAddressDataProvider
      */
     public function __construct(
         CompositeConfigProvider $configProvider,
         Session $checkoutSession,
         CheckoutData $checkoutData,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        HttpContext $httpContext,
+        CustomerRepositoryInterface $customerRepository,
+        CustomerAddressDataProvider $customerAddressDataProvider
     ) {
         $this->configProvider = $configProvider;
         $this->checkoutSession = $checkoutSession;
         $this->checkoutData = $checkoutData;
         $this->logger = $logger;
+        $this->httpContext = $httpContext;
+        $this->customerRepository = $customerRepository;
+        $this->customerAddressDataProvider = $customerAddressDataProvider;
     }
 
     /**
@@ -69,5 +100,51 @@ class ExpressPay implements ArgumentInterface
             $this->logger->error('ExpressPay: ' . $e->getMessage());
             return [];
         }
+    }
+
+    public function isCustomerLoggedIn(): bool
+    {
+        return (bool)$this->httpContext->getValue(CustomerContext::CONTEXT_AUTH);
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function getCustomerData(): array
+    {
+        $customerData = [];
+
+        if (!$this->isCustomerLoggedIn()) {
+            return $customerData;
+        }
+
+        try {
+            /** @var CustomerInterface&Customer $customer */
+            $customer = $this->getCustomer();
+        } catch (LocalizedException $localizedException) {
+            return $customerData;
+        }
+
+        $customerData = $customer->__toArray();
+
+        try {
+            $customerData['addresses'] = $this->customerAddressDataProvider->getAddressDataByCustomer($customer);
+        } catch (LocalizedException $e) {
+            $customerData['addresses'] = [];
+        }
+
+        return $customerData;
+    }
+
+    /**
+     * @throws NoSuchEntityException
+     * @throws LocalizedException
+     */
+    private function getCustomer(): CustomerInterface
+    {
+        /** @var int $customerId */
+        $customerId = $this->httpContext->getValue('customer_id');
+
+        return $this->customerRepository->getById($customerId);
     }
 }

--- a/ViewModel/ExpressPay.php
+++ b/ViewModel/ExpressPay.php
@@ -50,6 +50,7 @@ class ExpressPay implements ArgumentInterface
      * @var CustomerRepositoryInterface
      */
     private $customerRepository;
+
     /**
      * @var CustomerAddressDataProvider
      */

--- a/view/frontend/templates/express-pay-minicart.phtml
+++ b/view/frontend/templates/express-pay-minicart.phtml
@@ -2,10 +2,29 @@
 
 declare(strict_types=1);
 
+use Bold\CheckoutPaymentBooster\ViewModel\ExpressPay;
+use Magento\Framework\View\Element\Template;
+
+/** @var Template $block */
+
+/** @var ExpressPay $expressPayViewModel */
+$expressPayViewModel = $block->getData('express_pay_view_model');
+$isCustomerLoggedIn = $expressPayViewModel->isCustomerLoggedIn();
+$customerData = $expressPayViewModel->getCustomerData();
 ?>
 <div id="express-pay-container-minicart" data-testid="express-pay-container-minicart">
     <div id="express-pay-buttons-minicart"></div>
 </div>
+
+<script>
+    if (!window.hasOwnProperty('isCustomerLoggedIn')) {
+        window.isCustomerLoggedIn = <?= /* @noEscape */ json_encode($isCustomerLoggedIn) ?>;
+    }
+
+    if (!window.hasOwnProperty('customerData')) {
+        window.customerData = <?= /* @noEscape */ json_encode($customerData) ?>;
+    }
+</script>
 
 <script type="text/x-magento-init">
     {

--- a/view/frontend/templates/express-pay-product.phtml
+++ b/view/frontend/templates/express-pay-product.phtml
@@ -2,10 +2,29 @@
 
 declare(strict_types=1);
 
+use Bold\CheckoutPaymentBooster\ViewModel\ExpressPay;
+use Magento\Framework\View\Element\Template;
+
+/** @var Template $block */
+
+/** @var ExpressPay $expressPayViewModel */
+$expressPayViewModel = $block->getData('express_pay_view_model');
+$isCustomerLoggedIn = $expressPayViewModel->isCustomerLoggedIn();
+$customerData = $expressPayViewModel->getCustomerData();
 ?>
 <div id="express-pay-container-product" data-testid="express-pay-container-product">
     <div id="express-pay-buttons-product-details"></div>
 </div>
+
+<script>
+    if (!window.hasOwnProperty('isCustomerLoggedIn')) {
+        window.isCustomerLoggedIn = <?= /* @noEscape */ json_encode($isCustomerLoggedIn) ?>;
+    }
+
+    if (!window.hasOwnProperty('customerData')) {
+        window.customerData = <?= /* @noEscape */ json_encode($customerData) ?>;
+    }
+</script>
 
 <script type="text/x-magento-init">
     {


### PR DESCRIPTION
Restores logic for setting customer data and authentication state in the browser's `window` object removed by commit f268c4a6.

Fixes [CHK-7953](https://boldapps.atlassian.net/browse/CHK-7953)

[CHK-7953]: https://boldapps.atlassian.net/browse/CHK-7953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ