### PR TITLE
CHK-8045: Release Version 2.4.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "license": [
     "MIT"
   ],
-  "version": "2.4.3",
+  "version": "2.4.4",
   "require": {
     "magento/framework": ">=102.0.1 <103.0.8",
     "magento/module-checkout": ">=100.3.1 <100.4.8",


### PR DESCRIPTION
### Release Notes

- CHK-8046: Fix Incompatibility With Magento 2.3.x and  PHP 7.x Versions (#250)

Resolves [CHK-8045](https://boldapps.atlassian.net/browse/CHK-8045)

[CHK-8045]: https://boldapps.atlassian.net/browse/CHK-8045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ