### PR TITLE
CHK-8035 - render Place Order button for credit card gateways

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/bold-spi.js
+++ b/view/frontend/web/js/view/payment/method-renderer/bold-spi.js
@@ -178,7 +178,8 @@ define([
                 this.isVisible(false);
             }
 
-            if (window?.boldPaymentsInstance?.state?.paypal?.ppcpCredentials?.credentials?.standard_payments) {
+            const isPlaceOrderButtonNotVisible = paymentsInstance.paymentGateways?.every((paymentGateway) => paymentGateway.gateway_services.credit_card_form === false);
+            if (isPlaceOrderButtonNotVisible) {
                 this.isPlaceOrderButtonVisible(false);
             }
         },


### PR DESCRIPTION
Aligns the rendering of the "Place Order" button in the SPI frame to work with multiple payment gateways.

Fixes [CHK-8035](https://boldapps.atlassian.net/browse/CHK-8035)

[CHK-8035]: https://boldapps.atlassian.net/browse/CHK-8035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ