### PR TITLE
CHK-8104: Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
-* @davemacaulay @kshorten42 @JosephLeedy
-
-/view/ @davemacaulay @kshorten42 @JosephLeedy @nicolenorman
+* @bold-commerce/magento-code-owners


### PR DESCRIPTION
We want to update our codeowners to use a GitHub team to expand who can be in charge of reviewing code.

Relates to [CHK-8014](https://boldapps.atlassian.net/browse/CHK-8104)