### PR TITLE
CHK-8322: Add version tolerance to ppcp fastlane

### DIFF
--- a/view/frontend/web/js/model/fastlane.js
+++ b/view/frontend/web/js/model/fastlane.js
@@ -134,8 +134,11 @@ define([
          * @return {Promise<void>}
          */
         buildPPCPFastlaneInstance: async function (gatewayData) {
-            await loadScriptAction('bold_ppcp_fastlane_hosted_fields', 'braintree.hostedFields');
-            await loadScriptAction('bold_ppcp_fastlane_client', 'braintree.client');
+            const hostedFields = await loadScriptAction('bold_ppcp_fastlane_hosted_fields', 'braintree.hostedFields');
+            const client = await loadScriptAction('bold_ppcp_fastlane_client', 'braintree.client');
+            if (!window.braintree.version) {
+                window.braintree.version = client.VERSION;
+            }
             let debugMode = '';
             if (gatewayData.is_test_mode) {
                 debugMode = '&debug=true';


### PR DESCRIPTION
#### Overview

Setting `window.braintree.version` to force PPCP Fastlane to load the specified version.