### PR TITLE
CHK-8350: Increment version to 2.5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "license": [
     "MIT"
   ],
-  "version": "2.5.4",
+  "version": "2.5.5",
   "require": {
     "php": "^7.2 || ^8.0",
     "ext-curl": "*",


### PR DESCRIPTION
## What's Changed
* CHK-8322: Add version tolerance to ppcp fastlane by @kfalkowski11 in https://github.com/bold-commerce/adobe-commerce-bold-checkout-payment-booster/pull/283


**Full Changelog**: https://github.com/bold-commerce/adobe-commerce-bold-checkout-payment-booster/compare/v2.5.4...v2.5.5