### PR TITLE
CHK-9302: Bold Checkout API integration Key exchange

### DIFF
--- a/Api/Integration/ValidateApiInterface.php
+++ b/Api/Integration/ValidateApiInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\CheckoutPaymentBooster\Api\Integration;
+
+use Bold\CheckoutPaymentBooster\Api\Data\Http\Client\ResultInterface;
+
+/**
+ * Validate Bold Checkout API Integration.
+ */
+interface ValidateApiInterface
+{
+    /**
+     * Validate Bold Checkout API Integration.
+     *
+     * @param string $shopId
+     * @return \Bold\CheckoutPaymentBooster\Api\Data\Http\Client\ResultInterface
+     */
+    public function validate(
+        string $shopId,
+    ): ResultInterface;
+}

--- a/Block/Adminhtml/System/Config/Form/Field/IntegrateCheckoutApiButton.php
+++ b/Block/Adminhtml/System/Config/Form/Field/IntegrateCheckoutApiButton.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\CheckoutPaymentBooster\Block\Adminhtml\System\Config\Form\Field;
+
+use Magento\Config\Block\System\Config\Form\Field;
+use Magento\Framework\Data\Form\Element\AbstractElement;
+use Magento\Backend\Block\Template\Context;
+use Magento\Framework\UrlInterface;
+
+/**
+ * Class IntegrateCheckoutApiButton
+ *
+ * Represents a button element used for exchanging integration API key with Bold Checkout and runs validation.
+ * This class extends the Field class and primarily focuses on rendering
+ * the button and generating the corresponding AJAX URL for the export action.
+ */
+class IntegrateCheckoutApiButton extends Field
+{
+    /** @var UrlInterface  */
+    private $urlBuilder;
+
+    /**
+     * Constructor for the class, initializing context and URL builder.
+     *
+     * @param Context $context The context object containing resources and configurations.
+     * @param array $data Optional data array for additional configuration.
+     * @return void
+     * @phpstan-ignore-next-line
+     */
+    public function __construct(
+        Context $context,
+        array $data = []
+    ) {
+        parent::__construct($context, $data);
+        $this->urlBuilder = $context->getUrlBuilder();
+    }
+
+    /**
+     * Generates the HTML content for the specified element.
+     *
+     * @param AbstractElement $element The element for which the HTML is to be generated.
+     * @return string The generated HTML content.
+     */
+    protected function _getElementHtml(AbstractElement $element): string
+    {
+        return sprintf(
+            '
+                <div style="margin-top: 5px;">
+                    <button type="button" class="action-default scalable"
+                        onclick="window.location.href=\'%s\'">
+                        <span>%s</span>
+                    </button>
+                </div>
+                ',
+            $this->getAjaxUrl(),
+            __('Integrate Bold Checkout API')
+        );
+    }
+
+    /**
+     * Generates the AJAX URL to trigger Bold Checkout API integration.
+     *
+     * @return string The AJAX URL used to trigger Bold Checkout API integration.
+     */
+    public function getAjaxUrl(): string
+    {
+        return $this->urlBuilder->getUrl('bold_booster/integration/integrate');
+    }
+}

--- a/Controller/Adminhtml/Integration/Integrate.php
+++ b/Controller/Adminhtml/Integration/Integrate.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\CheckoutPaymentBooster\Controller\Adminhtml\Integration;
+
+use Bold\CheckoutPaymentBooster\Model\Config;
+use Bold\CheckoutPaymentBooster\Model\GenerateSharedSecret;
+use Bold\CheckoutPaymentBooster\Model\Integration\IntegrateBoldCheckout;
+use Exception;
+use Magento\Backend\App\Action;
+use Magento\Backend\App\Action\Context;
+use Magento\Framework\App\Cache\TypeListInterface;
+use Magento\Framework\App\ResponseInterface;
+use Magento\Framework\Controller\ResultInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Message\ManagerInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Handles the shared secret key exchange with Bold Checkout for API Integration
+ */
+class Integrate extends Action
+{
+    /** @var ManagerInterface  */
+    protected $messageManager;
+
+    /**
+     * @var Config
+     */
+    private $config;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @var GenerateSharedSecret
+     */
+    private $generateSharedSecret;
+
+    /**
+     * @var IntegrateBoldCheckout
+     */
+    private $integrateBoldCheckout;
+
+    /**
+     * @var TypeListInterface
+     */
+    private $cacheTypeList;
+
+    /** @var LoggerInterface */
+    private $logger;
+
+    /**
+     * Constructor method for initializing dependencies.
+     *
+     * @param Context $context The application context instance.
+     * @param Config $config
+     * @param StoreManagerInterface $storeManager
+     * @param GenerateSharedSecret $generateSharedSecret
+     * @param IntegrateBoldCheckout $integrateBoldCheckout
+     * @param TypeListInterface $cacheTypeList
+     * @param LoggerInterface $logger
+     * @return void
+     */
+    public function __construct(
+        Context $context,
+        Config $config,
+        StoreManagerInterface $storeManager,
+        GenerateSharedSecret $generateSharedSecret,
+        IntegrateBoldCheckout $integrateBoldCheckout,
+        TypeListInterface $cacheTypeList,
+        LoggerInterface       $logger
+    ) {
+        parent::__construct($context);
+        $this->messageManager = $context->getMessageManager();
+        $this->config = $config;
+        $this->storeManager = $storeManager;
+        $this->generateSharedSecret = $generateSharedSecret;
+        $this->integrateBoldCheckout = $integrateBoldCheckout;
+        $this->cacheTypeList = $cacheTypeList;
+        $this->logger = $logger;
+    }
+
+    /**
+     * Executes the action to integrate with Bold Checkout.
+     *
+     * @return ResponseInterface|ResultInterface
+     */
+    public function execute()
+    {
+        try {
+            $this->logger->info('Calling integrate Bold Checkout APIs'); // TODO: Change to Bold Logger when helper implemented
+            $websiteId = (int) $this->storeManager->getWebsite(true)->getId();
+            $sharedSecret = $this->configureSharedSecret($websiteId);
+
+            $this->integrateBoldCheckout->execute($websiteId, $sharedSecret);
+
+            $this->config->setCheckoutApiIntegrationIsEnabled($websiteId, true);
+            $this->config->setCheckoutApiIntegrationIsValidated($websiteId, true);
+            $this->cacheTypeList->cleanType('config');
+
+            $this->messageManager->addNoticeMessage('Config cache cleared.');
+            $this->messageManager->addSuccessMessage('Bold Checkout API integration configured.');
+        } catch (Exception $e) {
+            $this->logger->error($e->getMessage()); // TODO: Change to Bold Logger when helper implemented
+            $this->messageManager->addErrorMessage(sprintf('Unable to configure Bold Checkout API integration: %s', $e->getMessage()));
+        }
+
+        return $this->_redirect($this->_redirect->getRefererUrl());
+    }
+
+    /**
+     * Load or generate new shared secret.
+     *
+     * @param int $websiteId
+     * @return string
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     */
+    private function configureSharedSecret(int $websiteId): string
+    {
+        $sharedSecret = $this->config->getSharedSecret($websiteId);
+        if (!$sharedSecret) {
+            $sharedSecret = $this->generateSharedSecret->execute();
+            $this->config->setSharedSecret($websiteId, $sharedSecret);
+        }
+        return $sharedSecret;
+    }
+}

--- a/Controller/Adminhtml/Log/Export.php
+++ b/Controller/Adminhtml/Log/Export.php
@@ -81,7 +81,7 @@ class Export extends Action
                     self::LOG_FILENAME . '"', true)
                 ->setContents($contents);
         } catch (Exception $e) {
-            $this->messageManager->addErrorMessage('Unable to read log file: %1', $e->getMessage());
+            $this->messageManager->addErrorMessage(sprintf('Unable to read log file: %s', $e->getMessage()));
             return $this->_redirect($this->_redirect->getRefererUrl());
         }
     }

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -26,6 +26,8 @@ class Config
     private const PATH_INTEGRATION_API_URL = 'checkout/bold_checkout_payment_booster_advanced/api_url';
     private const PATH_EPS_URL = 'checkout/bold_checkout_payment_booster_advanced/eps_url';
     private const PATH_STATIC_EPS_URL = 'checkout/bold_checkout_payment_booster_advanced/static_eps_url';
+    private const PATH_CHECKOUT_API_INTEGRATION_ENABLED = 'checkout/bold_checkout_payment_booster_advanced/enable_checkout_api_integration';
+    private const PATH_CHECKOUT_API_INTEGRATION_VALIDATED = 'checkout/bold_checkout_payment_booster_advanced/is_checkout_api_integration_validated';
     private const PATH_LOG_IS_ENABLED = 'checkout/bold_checkout_payment_booster_advanced/log_enabled';
     private const PATH_SHARED_SECRET = 'checkout/bold_checkout_payment_booster/shared_secret';
     private const PATH_CONFIGURATION_GROUP_LABEL = 'checkout/bold_checkout_payment_booster/configuration_group_label';
@@ -195,6 +197,70 @@ class Config
     {
         return $this->scopeConfig->getValue(
             self::PATH_SHOP_ID,
+            ScopeInterface::SCOPE_WEBSITES,
+            $websiteId
+        );
+    }
+
+    /**
+     * Set if checkout api integration is enabled.
+     *
+     * @param int $websiteId
+     * @param bool $isEnabled
+     * @return void
+     */
+    public function setCheckoutApiIntegrationIsEnabled(int $websiteId, bool $isEnabled): void
+    {
+        $this->configWriter->save(
+            self::PATH_CHECKOUT_API_INTEGRATION_ENABLED,
+            (string) $isEnabled,
+            ScopeInterface::SCOPE_WEBSITES,
+            $websiteId
+        );
+    }
+
+    /**
+     * Check if checkout api integration is enabled.
+     *
+     * @param int $websiteId
+     * @return bool
+     */
+    public function getCheckoutApiIntegrationIsEnabled(int $websiteId): bool
+    {
+        return $this->scopeConfig->isSetFlag(
+            self::PATH_CHECKOUT_API_INTEGRATION_ENABLED,
+            ScopeInterface::SCOPE_WEBSITES,
+            $websiteId
+        );
+    }
+
+    /**
+     * Set if checkout api integration is validated.
+     *
+     * @param int $websiteId
+     * @param bool $isValidated
+     * @return void
+     */
+    public function setCheckoutApiIntegrationIsValidated(int $websiteId, bool $isValidated): void
+    {
+        $this->configWriter->save(
+            self::PATH_CHECKOUT_API_INTEGRATION_VALIDATED,
+            (string) $isValidated,
+            ScopeInterface::SCOPE_WEBSITES,
+            $websiteId
+        );
+    }
+
+    /**
+     * Check if checkout api integration is validated.
+     *
+     * @param int $websiteId
+     * @return bool
+     */
+    public function getCheckoutApiIntegrationIsValidated(int $websiteId): bool
+    {
+        return $this->scopeConfig->isSetFlag(
+            self::PATH_CHECKOUT_API_INTEGRATION_VALIDATED,
             ScopeInterface::SCOPE_WEBSITES,
             $websiteId
         );

--- a/Model/GenerateSharedSecret.php
+++ b/Model/GenerateSharedSecret.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Bold\CheckoutPaymentBooster\Model\RemoteStateAuthority;
+namespace Bold\CheckoutPaymentBooster\Model;
 
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Math\Random;

--- a/Model/Integration/IntegrateBoldCheckout.php
+++ b/Model/Integration/IntegrateBoldCheckout.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\CheckoutPaymentBooster\Model\Integration;
+
+use Bold\CheckoutPaymentBooster\Model\Http\BoldClient;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\UrlInterface;
+use Magento\Store\Api\Data\WebsiteInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Store\Model\Website;
+
+/**
+ * Shared secret registration service
+ */
+class IntegrateBoldCheckout
+{
+    private const INTEGRATION_URL = 'checkout/shop/{{shopId}}/api_config';
+
+    /**
+     * @var BoldClient
+     */
+    private $boldClient;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @param BoldClient $boldClient
+     * @param StoreManagerInterface $storeManager
+     */
+    public function __construct(
+        BoldClient $boldClient,
+        StoreManagerInterface $storeManager
+    ) {
+        $this->boldClient = $boldClient;
+        $this->storeManager = $storeManager;
+    }
+
+    /**
+     * Update (or register) shared secret with Bold Checkout API Integration.
+     *
+     * @param int $websiteId
+     * @param string $sharedSecret
+     * @return void
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     */
+    public function execute(int $websiteId, string $sharedSecret): void
+    {
+        /** @var WebsiteInterface&Website $website */
+        $website = $this->storeManager->getWebsite($websiteId);
+        $storeId = $website->getDefaultStore()->getId();
+        $body = [
+            'api_url' => $this->storeManager->getStore($storeId)->getBaseUrl(UrlInterface::URL_TYPE_WEB) . 'rest/V1',
+            'api_key' => $sharedSecret,
+        ];
+
+        $result = $this->boldClient->post($websiteId, self::INTEGRATION_URL, $body);
+
+        if ($result->getStatus() === 422 && $result->getErrors()) {
+            $message = isset(current($result->getErrors())['message'])
+                ? __(current($result->getErrors())['message'])
+                : __('Failed to configure integration.');
+            throw new LocalizedException($message);
+        } elseif ($result->getStatus() !== 200) {
+            $message = __('Failed to configure integration.');
+            throw new LocalizedException($message);
+        }
+    }
+}

--- a/Model/Integration/ValidateApi.php
+++ b/Model/Integration/ValidateApi.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\CheckoutPaymentBooster\Model\Integration;
+
+use Bold\CheckoutPaymentBooster\Api\Data\Http\Client\ResultInterface;
+use Bold\CheckoutPaymentBooster\Api\Data\Http\Client\ResultInterfaceFactory;
+use Bold\CheckoutPaymentBooster\Api\Integration\ValidateApiInterface;
+use Bold\CheckoutPaymentBooster\Model\Http\SharedSecretAuthorization;
+use Bold\CheckoutPaymentBooster\Model\ResourceModel\GetWebsiteIdByShopId;
+use Magento\Framework\Exception\AuthorizationException;
+
+class ValidateApi implements ValidateApiInterface
+{
+    /**
+     * @var SharedSecretAuthorization
+     */
+    private $sharedSecretAuthorization;
+
+    /**
+     * @var GetWebsiteIdByShopId
+     */
+    private $getWebsiteIdByShopId;
+    /**
+     * @var ResultInterfaceFactory
+     */
+    private $responseFactory;
+
+    /**
+     * @param ResultInterfaceFactory $responseFactory
+     * @param SharedSecretAuthorization $sharedSecretAuthorization
+     * @param GetWebsiteIdByShopId $getWebsiteIdByShopId
+     */
+    public function __construct(
+        ResultInterfaceFactory $responseFactory,
+        SharedSecretAuthorization $sharedSecretAuthorization,
+        GetWebsiteIdByShopId $getWebsiteIdByShopId
+    ) {
+        $this->responseFactory = $responseFactory;
+        $this->sharedSecretAuthorization = $sharedSecretAuthorization;
+        $this->getWebsiteIdByShopId = $getWebsiteIdByShopId;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function validate(
+        string $shopId
+    ): ResultInterface {
+        $websiteId = $this->getWebsiteIdByShopId->getWebsiteId($shopId);
+        // Do not remove this check until resource authorized by ACL.
+        if (!$this->sharedSecretAuthorization->isAuthorized($websiteId)) {
+            // Shared secret authorization failed.
+            throw new AuthorizationException(__('The consumer isn\'t authorized to access resource.'));
+        }
+
+        return $this->responseFactory->create(['validation' => 'success']);
+    }
+}

--- a/Observer/Checkout/ConfigureShopObserver.php
+++ b/Observer/Checkout/ConfigureShopObserver.php
@@ -6,8 +6,8 @@ namespace Bold\CheckoutPaymentBooster\Observer\Checkout;
 
 use Bold\CheckoutPaymentBooster\Model\Config;
 use Bold\CheckoutPaymentBooster\Model\Eps\AddDomainToCorsAllowList;
+use Bold\CheckoutPaymentBooster\Model\GenerateSharedSecret;
 use Bold\CheckoutPaymentBooster\Model\PaymentBooster\FlowService;
-use Bold\CheckoutPaymentBooster\Model\RemoteStateAuthority\GenerateSharedSecret;
 use Bold\CheckoutPaymentBooster\Model\RemoteStateAuthority\RegisterSharedSecret;
 use Bold\CheckoutPaymentBooster\Model\ShopId;
 use Exception;

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -99,6 +99,19 @@
                     <validate>required-url</validate>
                     <comment><![CDATA[Bold static EPS URL. Do not change.]]></comment>
                 </field>
+                <field id="enable_checkout_api_integration" translate="label" type="select" sortOrder="50" showInWebsite="1">
+                    <label>Enable Bold Checkout API Integration</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment><![CDATA[ Enable Bold Checkout API integration for Agentic commerce. ]]></comment>
+                </field>
+                <field id="integrate_checkout_api_button" translate="label" type="text" sortOrder="50" showInWebsite="1">
+                    <label>Integrate Bold Checkout API</label>
+                    <frontend_model>Bold\CheckoutPaymentBooster\Block\Adminhtml\System\Config\Form\Field\IntegrateCheckoutApiButton</frontend_model>
+                    <comment><![CDATA[ Exchange integration secure key with Bold Checkout and validate key with successful API integration .]]></comment>
+                    <depends>
+                        <field id="enable_checkout_api_integration">1</field>
+                    </depends>
+                </field>
                 <field id="log_enabled" translate="label" type="select" sortOrder="50" showInWebsite="1">
                     <label>Enable Bold Checkout Requests Logs</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -11,6 +11,7 @@
     <preference for="Bold\CheckoutPaymentBooster\Api\Order\GuestHydrateOrderInterface" type="Bold\CheckoutPaymentBooster\Model\Order\GuestHydrateOrder"/>
     <preference for="Bold\CheckoutPaymentBooster\Api\Order\HydrateOrderInterface" type="Bold\CheckoutPaymentBooster\Model\Order\HydrateOrder"/>
     <preference for="Bold\CheckoutPaymentBooster\Api\Order\UpdatePaymentsInterface" type="Bold\CheckoutPaymentBooster\Model\Order\UpdatePayments"/>
+    <preference for="Bold\CheckoutPaymentBooster\Api\Integration\ValidateApiInterface" type="Bold\CheckoutPaymentBooster\Model\Integration\ValidateApi"/>
     <preference for="Bold\CheckoutPaymentBooster\Api\Data\Order\Payment\PaymentInterface" type="Bold\CheckoutPaymentBooster\Model\Order\Payment"/>
     <preference for="Bold\CheckoutPaymentBooster\Api\Data\Order\Payment\TransactionInterface" type="Bold\CheckoutPaymentBooster\Model\Order\Transaction"/>
     <preference for="Bold\CheckoutPaymentBooster\Api\Data\Order\Payment\ResultInterface" type="Bold\CheckoutPaymentBooster\Model\Order\UpdatePayments\Result"/>

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -64,4 +64,11 @@
             <resource ref="anonymous" />
         </resources>
     </route>
+    <route url="/V1/shops/:shopId/integration/validate" method="POST">
+        <service class="Bold\CheckoutPaymentBooster\Api\Integration\ValidateApiInterface" method="validate"/>
+        <resources>
+            <!-- Authorization performed in service class -->
+            <resource ref="anonymous" />
+        </resources>
+    </route>
 </routes>


### PR DESCRIPTION
* Add Bold Checkout API integration enablement flag.
* Internally add Bold Checkout API integration validated flag.
* Add endpoint `/V1/shops/:shopId/integration/validate` to receive checkout validation call of the authorization.

## Screenshots
* Enable
<img width="1155" height="165" alt="Screenshot 2025-10-02 at 4 07 08 PM" src="https://github.com/user-attachments/assets/50c04167-5db1-488c-9471-6c8a9f5036a8" />

* Integrate manually
<img width="1141" height="257" alt="Screenshot 2025-10-02 at 4 07 27 PM" src="https://github.com/user-attachments/assets/a9d19c5c-081c-4c62-b433-686c0f7f4275" />

* Successful to configure integration
<img width="887" height="563" alt="Screenshot 2025-10-03 at 12 44 34 PM" src="https://github.com/user-attachments/assets/2c8220fa-c07c-4dd8-b7b4-b9214a04fb55" />

* Failed to configure Integration
<img width="969" height="451" alt="Screenshot 2025-10-03 at 11 57 37 AM" src="https://github.com/user-attachments/assets/422e3351-2758-4600-891a-b43e94ffa3e0" />
