### PR TITLE
CHK-9309: Integrate Checkout Api CLI

### DIFF
--- a/Console/Command/IntegrateCheckoutApi.php
+++ b/Console/Command/IntegrateCheckoutApi.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\CheckoutPaymentBooster\Console\Command;
+
+use Bold\CheckoutPaymentBooster\Model\Config;
+use Bold\CheckoutPaymentBooster\Model\GenerateSharedSecret;
+use Bold\CheckoutPaymentBooster\Model\Integration\IntegrateBoldCheckout;
+use Exception;
+use Magento\Framework\App\Cache\TypeListInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class IntegrateCheckoutApi extends Command
+{
+    private const WEBSITE_ID = 'websiteId';
+
+    /**
+     * @var Config
+     */
+    private $config;
+
+    /**
+     * @var GenerateSharedSecret
+     */
+    private $generateSharedSecret;
+
+    /**
+     * @var IntegrateBoldCheckout
+     */
+    private $integrateBoldCheckout;
+
+    /**
+     * @var TypeListInterface
+     */
+    private $cacheTypeList;
+
+    /**
+     * Constructor method for initializing dependencies.
+     *
+     * @param Config $config
+     * @param GenerateSharedSecret $generateSharedSecret
+     * @param IntegrateBoldCheckout $integrateBoldCheckout
+     * @param TypeListInterface $cacheTypeList
+     * @return void
+     */
+    public function __construct(
+        Config $config,
+        GenerateSharedSecret $generateSharedSecret,
+        IntegrateBoldCheckout $integrateBoldCheckout,
+        TypeListInterface $cacheTypeList
+    ) {
+        parent::__construct();
+        $this->config = $config;
+        $this->generateSharedSecret = $generateSharedSecret;
+        $this->integrateBoldCheckout = $integrateBoldCheckout;
+        $this->cacheTypeList = $cacheTypeList;
+    }
+
+    protected function configure(): void
+    {
+        $this->setName('bold:integrate:checkout:api');
+        $this->setDescription('Enable Bold Checkout API integration for Agentic commerce.');
+        $this->addOption(
+            self::WEBSITE_ID,
+            "w",
+            InputOption::VALUE_REQUIRED,
+            'Website Id'
+        );
+
+        parent::configure();
+    }
+
+    /**
+     * Execute the command
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
+     * @return int
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if ($websiteId = (int) $input->getOption(self::WEBSITE_ID)) {
+            $output->writeln('<info>Provided Website id is `' . $websiteId . '`</info>');
+        } else {
+            $errorMessage = 'The "--websiteId" option is required.';
+            $spaces = str_repeat(' ', mb_strlen($errorMessage));
+            $output->writeln([
+                '<error>',
+                '  ' . $spaces . '  ',
+                '  ' . $errorMessage . '  ',
+                '  ' . $spaces . '  ',
+                '</error>',
+                '<info>',
+                'bold:integrate:checkout:api [-w|--websiteId WEBSITEID]',
+                '</info>'
+            ]);
+            return self::INVALID;
+        }
+
+        try {
+            $output->writeln('<info>Calling integrate Bold Checkout APIs.</info>');
+
+            $sharedSecret = $this->configureSharedSecret($websiteId);
+            $this->integrateBoldCheckout->execute($websiteId, $sharedSecret);
+
+            $this->config->setCheckoutApiIntegrationIsEnabled($websiteId, true);
+            $this->config->setCheckoutApiIntegrationIsValidated($websiteId, true);
+            $this->cacheTypeList->cleanType('config');
+
+            $output->writeln([
+                '',
+                '<info>Bold Checkout API integration configured.</info>',
+                '<comment>Config updated and cache cleared.</comment>',
+                ''
+            ]);
+        } catch (Exception $e) {
+            $errorMessage = sprintf('Unable to configure Bold Checkout API integration: %s', $e->getMessage());
+            $spaces = str_repeat(' ', mb_strlen($errorMessage));
+            $output->writeln([
+                '<error>',
+                '  ' . $spaces . '  ',
+                '  ' . $errorMessage . '  ',
+                '  ' . $spaces . '  ',
+                '</error>',
+            ]);
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Load or generate new shared secret.
+     *
+     * @param int $websiteId
+     * @return string
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     */
+    private function configureSharedSecret(int $websiteId): string
+    {
+        $sharedSecret = $this->config->getSharedSecret($websiteId);
+        if (!$sharedSecret) {
+            $sharedSecret = $this->generateSharedSecret->execute();
+            $this->config->setSharedSecret($websiteId, $sharedSecret);
+        }
+        return $sharedSecret;
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -211,4 +211,13 @@
             </argument>
         </arguments>
     </type>
+
+    <type name="Magento\Framework\Console\CommandListInterface">
+        <arguments>
+            <argument name="commands" xsi:type="array">
+                <item name="checkout_payment_booster_integrate_checkout_api" xsi:type="object">Bold\CheckoutPaymentBooster\Console\Command\IntegrateCheckoutApi</item>
+            </argument>
+        </arguments>
+    </type>
+
 </config>


### PR DESCRIPTION
Create a command for the CLI to integrate Checkout API with the key exchange.

## Successfull Command
<img width="827" height="130" alt="Screenshot 2025-10-06 at 11 52 49 AM" src="https://github.com/user-attachments/assets/e7b3cf2f-94b0-4d59-a3c2-011bf9122d64" />

<img width="755" height="128" alt="Screenshot 2025-10-06 at 11 52 56 AM" src="https://github.com/user-attachments/assets/8757d468-ff04-45d8-ac8e-8d9d2b2565f0" />

## Failure Command
<img width="1146" height="149" alt="Screenshot 2025-10-06 at 11 53 23 AM" src="https://github.com/user-attachments/assets/3a63e340-b44a-40e8-9892-ae015176ad5a" />

## Invalid Command
<img width="715" height="164" alt="Screenshot 2025-10-06 at 11 54 00 AM" src="https://github.com/user-attachments/assets/e41e7364-ac12-4f1c-aa59-9ea7a21a2e9a" />

<img width="745" height="146" alt="Screenshot 2025-10-06 at 11 54 15 AM" src="https://github.com/user-attachments/assets/5d7221fb-75a1-4119-bf8d-4c409382c518" />
