### PR TITLE
CHK-9543: Handling HTTP status on Authorize

### DIFF
--- a/Model/Http/BoldClient.php
+++ b/Model/Http/BoldClient.php
@@ -13,6 +13,7 @@ use Bold\CheckoutPaymentBooster\Model\Http\Client\Command\PatchCommand;
 use Bold\CheckoutPaymentBooster\Model\Http\Client\Command\PostCommand;
 use Bold\CheckoutPaymentBooster\Model\Http\Client\Command\PutCommand;
 use Bold\CheckoutPaymentBooster\Model\Http\Client\UserAgent;
+use Magento\Framework\Exception\LocalizedException;
 
 /**
  * Client to perform http request to Bold.
@@ -89,12 +90,20 @@ class BoldClient implements ClientInterface
      * @param int $websiteId
      * @param string $path
      * @return \Bold\CheckoutPaymentBooster\Api\Data\Http\Client\ResultInterface
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function get(int $websiteId, string $path): ResultInterface
     {
         $path = $this->getUrl($websiteId, $path);
         $headers = $this->getHeaders($websiteId);
-        return $this->getCommand->execute($websiteId, $path, $headers);
+        $result = $this->getCommand->execute($websiteId, $path, $headers);
+
+        $status = $result->getStatus();
+        if ($status === 0 || $status >= 400) {
+            throw new LocalizedException(__('Bold Checkout API GET request failed. Response status: ' . $status));
+        }
+
+        return $result;
     }
 
     /**
@@ -104,12 +113,20 @@ class BoldClient implements ClientInterface
      * @param string $path
      * @param mixed[] $data
      * @return \Bold\CheckoutPaymentBooster\Api\Data\Http\Client\ResultInterface
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function post(int $websiteId, string $path, array $data): ResultInterface
     {
         $path = $this->getUrl($websiteId, $path);
         $headers = $this->getHeaders($websiteId);
-        return $this->postCommand->execute($websiteId, $path, $headers, $data);
+        $result = $this->postCommand->execute($websiteId, $path, $headers, $data);
+
+        $status = $result->getStatus();
+        if ($status === 0 || $status >= 400) {
+            throw new LocalizedException(__('Bold Checkout API POST request failed. Response status: ' . $status));
+        }
+
+        return $result;
     }
 
     /**
@@ -119,12 +136,20 @@ class BoldClient implements ClientInterface
      * @param string $path
      * @param mixed[] $data
      * @return \Bold\CheckoutPaymentBooster\Api\Data\Http\Client\ResultInterface
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function put(int $websiteId, string $path, array $data): ResultInterface
     {
         $path = $this->getUrl($websiteId, $path);
         $headers = $this->getHeaders($websiteId);
-        return $this->putCommand->execute($websiteId, $path, $headers, $data);
+        $result = $this->putCommand->execute($websiteId, $path, $headers, $data);
+
+        $status = $result->getStatus();
+        if ($status === 0 || $status >= 400) {
+            throw new LocalizedException(__('Bold Checkout API PUT request failed. Response status: ' . $status));
+        }
+
+        return $result;
     }
 
     /**
@@ -134,12 +159,20 @@ class BoldClient implements ClientInterface
      * @param string $path
      * @param mixed[] $data
      * @return \Bold\CheckoutPaymentBooster\Api\Data\Http\Client\ResultInterface
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function patch(int $websiteId, string $path, array $data): ResultInterface
     {
         $path = $this->getUrl($websiteId, $path);
         $headers = $this->getHeaders($websiteId);
-        return $this->patchCommand->execute($websiteId, $path, $headers, $data);
+        $result = $this->patchCommand->execute($websiteId, $path, $headers, $data);
+
+        $status = $result->getStatus();
+        if ($status === 0 || $status >= 400) {
+            throw new LocalizedException(__('Bold Checkout API request failed. Response status: ' . $status));
+        }
+
+        return $result;
     }
 
     /**
@@ -149,12 +182,20 @@ class BoldClient implements ClientInterface
      * @param string $path
      * @param mixed[] $data
      * @return \Bold\CheckoutPaymentBooster\Api\Data\Http\Client\ResultInterface
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function delete(int $websiteId, string $path, array $data): ResultInterface
     {
         $path = $this->getUrl($websiteId, $path);
         $headers = $this->getHeaders($websiteId);
-        return $this->deleteCommand->execute($websiteId, $path, $headers, $data);
+        $result = $this->deleteCommand->execute($websiteId, $path, $headers, $data);
+
+        $status = $result->getStatus();
+        if ($status === 0 || $status >= 400) {
+            throw new LocalizedException(__('Bold Checkout API DELETE request failed. Response status: ' . $status));
+        }
+
+        return $result;
     }
 
     /**


### PR DESCRIPTION
- If a request to Bold Checkout times out, we want to treat it as an error, not a successful Magento order.
- This change is at the Bold client level, so it will handle any failure which is not due to business logic where $result->getErrors() is not populated in a generic way. Mostly this would be failures in transport.

**Before change:**
<img width="692" height="536" alt="image" src="https://github.com/user-attachments/assets/d086f776-24df-4594-8afd-3a4f8a0a4ecc" />

**After change:**
<img width="918" height="539" alt="image" src="https://github.com/user-attachments/assets/c44ce2f9-e64a-46c0-aeb2-ea16c8243c47" />