### PR TITLE
CHK-9543: Adding Fiserv CSP entries

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -21,6 +21,9 @@
                 <value id="bold_applepay" type="host">*.cdn-apple.com</value>
                 <value id="bold_nuvei_staging" type="host">ppp-test.safecharge.com</value>
                 <value id="bold_nuvei" type="host">secure.safecharge.com</value>
+                <value id="bold_fiserv_sdk" type="host">commercehub-secure-data-capture.fiservapps.com</value>
+                <value id="bold_fiserv_staging" type="host">connect-cert.fiservapis.com</value>
+                <value id="bold_fiserv_prod" type="host">connect.fiservapis.com</value>
             </values>
         </policy>
         <policy id="script-src">
@@ -38,6 +41,7 @@
                 <value id="bold_stripe" type="host">*.stripe.com</value>
                 <value id="bold_inline_script_hash" type="hash" algorithm="sha256">7nnKyr+RUZ9a44Hg3lYwjgkUx5VyFQwv2ZUhVw6N7J4=</value>
                 <value id="bold_nuvei" type="host">cdn.safecharge.com</value>
+                <value id="bold_fiserv_sdk" type="host">commercehub-secure-data-capture.fiservapps.com</value>
             </values>
         </policy>
         <policy id="frame-src">


### PR DESCRIPTION
- these allow us to load the Fiserv JS SDK, and allows Magento to tolerate calls from that SDK into Fiserv's API backend