### PR TITLE
CHK-9605: Block Bold session reuse on completed digital-wallet quotes [DO NOT MERGE]

### DIFF
--- a/Model/CheckoutData.php
+++ b/Model/CheckoutData.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Bold\CheckoutPaymentBooster\Model;
 
+use Bold\CheckoutPaymentBooster\Api\MagentoQuoteBoldOrderRepositoryInterface;
 use Bold\CheckoutPaymentBooster\Model\Eps\GetFastlaneStyles;
 use Exception;
 use Magento\Checkout\Model\Session;
@@ -46,12 +47,18 @@ class CheckoutData
     private $config;
 
     /**
+     * @var MagentoQuoteBoldOrderRepositoryInterface
+     */
+    private $magentoQuoteBoldOrderRepository;
+
+    /**
      * @param Session $checkoutSession
      * @param IsPaymentBoosterAvailable $isPaymentBoosterAvailable
      * @param InitOrderFromQuote $initOrderFromQuote
      * @param ResumeOrder $resumeOrder
      * @param GetFastlaneStyles $getFastlaneStyles
      * @param Config $config
+     * @param MagentoQuoteBoldOrderRepositoryInterface $magentoQuoteBoldOrderRepository
      */
     public function __construct(
         Session $checkoutSession,
@@ -59,7 +66,8 @@ class CheckoutData
         InitOrderFromQuote $initOrderFromQuote,
         ResumeOrder $resumeOrder,
         GetFastlaneStyles $getFastlaneStyles,
-        Config $config
+        Config $config,
+        MagentoQuoteBoldOrderRepositoryInterface $magentoQuoteBoldOrderRepository
     ) {
         $this->checkoutSession = $checkoutSession;
         $this->isPaymentBoosterAvailable = $isPaymentBoosterAvailable;
@@ -67,6 +75,7 @@ class CheckoutData
         $this->resumeOrder = $resumeOrder;
         $this->getFastlaneStyles = $getFastlaneStyles;
         $this->config = $config;
+        $this->magentoQuoteBoldOrderRepository = $magentoQuoteBoldOrderRepository;
     }
 
     /**
@@ -87,9 +96,20 @@ class CheckoutData
         if (!$this->isPaymentBoosterAvailable->isAvailable()) {
             return;
         }
-        if ($this->getPublicOrderId()) {
+
+        $existingPublicOrderId = $this->getPublicOrderId();
+
+        if ($existingPublicOrderId) {
+            $quoteId = (string)$quote->getId();
+            if ($this->magentoQuoteBoldOrderRepository->isQuoteProcessed($quoteId)) {
+                $this->resetCheckoutData();
+                $existingPublicOrderId = null;
+            }
+        }
+
+        if ($existingPublicOrderId) {
             $orderData = $this->resumeOrder->resume(
-                $this->getPublicOrderId(),
+                $existingPublicOrderId,
                 $websiteId
             );
             if ($orderData) {

--- a/Model/Order/SetCompleteState.php
+++ b/Model/Order/SetCompleteState.php
@@ -7,6 +7,7 @@ namespace Bold\CheckoutPaymentBooster\Model\Order;
 use Bold\CheckoutPaymentBooster\Api\MagentoQuoteBoldOrderRepositoryInterface;
 use Bold\CheckoutPaymentBooster\Model\Http\BoldClient;
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Model\Order;
 use Psr\Log\LoggerInterface;
@@ -76,7 +77,15 @@ class SetCompleteState
             $this->logger->error(__('Failed to set complete state for order with id="%1"', $order->getEntityId()));
             return;
         }
-        $quoteId = $order->getQuoteId();
-        $this->magentoQuoteBoldOrderRepository->saveStateAt((string) $quoteId);
+        $quoteId = (string)$order->getQuoteId();
+        $this->magentoQuoteBoldOrderRepository->saveStateAt($quoteId);
+
+        try {
+            $relation = $this->magentoQuoteBoldOrderRepository->getByQuoteId($quoteId);
+            $relation->setBoldOrderId('');
+            $this->magentoQuoteBoldOrderRepository->save($relation);
+        } catch (NoSuchEntityException $e) {
+            // Nothing to clear; relation may not exist for this path.
+        }
     }
 }

--- a/Plugin/Checkout/Model/SessionPlugin.php
+++ b/Plugin/Checkout/Model/SessionPlugin.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Bold\CheckoutPaymentBooster\Plugin\Checkout\Model;
 
+use Bold\CheckoutPaymentBooster\Model\CheckoutData;
 use Closure;
 use Magento\Checkout\Model\Session;
 use Magento\Framework\Exception\NoSuchEntityException;
@@ -18,9 +19,17 @@ class SessionPlugin
      */
     private $quoteRepository;
 
-    public function __construct(CartRepositoryInterface $quoteRepository)
-    {
+    /**
+     * @var CheckoutData
+     */
+    private $checkoutData;
+
+    public function __construct(
+        CartRepositoryInterface $quoteRepository,
+        CheckoutData $checkoutData
+    ) {
         $this->quoteRepository = $quoteRepository;
+        $this->checkoutData = $checkoutData;
     }
 
     public function aroundClearQuote(Session $subject, Closure $proceed): Session
@@ -41,6 +50,8 @@ class SessionPlugin
         if (!$lastQuote->getData('is_digital_wallets')) {
             return $proceed();
         }
+
+        $this->checkoutData->resetCheckoutData();
 
         return $subject;
     }

--- a/Plugin/Quote/Api/CartRepositoryInterfacePlugin.php
+++ b/Plugin/Quote/Api/CartRepositoryInterfacePlugin.php
@@ -52,11 +52,12 @@ class CartRepositoryInterfacePlugin
             return $result;
         }
 
-        if ($magentoQuoteBoldOrder->getBoldOrderId() === null) {
+        $boldOrderId = $magentoQuoteBoldOrder->getBoldOrderId();
+        if ($boldOrderId === null || $boldOrderId === '') {
             return $result;
         }
 
-        $cartExtension->setBoldOrderId($magentoQuoteBoldOrder->getBoldOrderId());
+        $cartExtension->setBoldOrderId($boldOrderId);
 
         return $result;
     }

--- a/Test/Integration/Model/CheckoutDataTest.php
+++ b/Test/Integration/Model/CheckoutDataTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\CheckoutPaymentBooster\Test\Integration\Model;
+
+use Bold\CheckoutPaymentBooster\Api\MagentoQuoteBoldOrderRepositoryInterface;
+use Bold\CheckoutPaymentBooster\Model\CheckoutData;
+use Bold\CheckoutPaymentBooster\Model\Eps\GetFastlaneStyles;
+use Bold\CheckoutPaymentBooster\Model\InitOrderFromQuote;
+use Bold\CheckoutPaymentBooster\Model\ResumeOrder;
+use Magento\Checkout\Model\Session;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\ResourceModel\Quote as QuoteResource;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @magentoAppArea frontend
+ * @magentoAppIsolation enabled
+ */
+class CheckoutDataTest extends TestCase
+{
+    private const EXISTING_PUBLIC_ORDER_ID = 'e5537d5a79264a53995b9ccf6b86225b46925006f6e24a59a8892fbb524b1aa0';
+
+    private const NEW_PUBLIC_ORDER_ID = 'aca5efca525f4748be5820d62d95c88b2e9b11b98bb643fc93b2109500a2f993';
+
+    /**
+     * @magentoConfigFixture current_website checkout/bold_checkout_payment_booster/shop_id test-shop-id
+     * @magentoConfigFixture current_website checkout/bold_checkout_payment_booster/is_payment_booster_enabled 1
+     * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/magento_quote_bold_order.php
+     */
+    public function testReplacesStalePublicOrderIdWhenQuoteAlreadyProcessed(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var Quote $quote */
+        $quote = $objectManager->create(Quote::class);
+        /** @var QuoteResource $quoteResource */
+        $quoteResource = $objectManager->create(QuoteResource::class);
+        /** @var Session $checkoutSession */
+        $checkoutSession = $objectManager->get(Session::class);
+        /** @var MagentoQuoteBoldOrderRepositoryInterface $magentoQuoteBoldOrderRepository */
+        $magentoQuoteBoldOrderRepository = $objectManager->create(MagentoQuoteBoldOrderRepositoryInterface::class);
+
+        $quoteResource->load($quote, 'test_order_item_with_items', 'reserved_order_id');
+        $quoteId = (string)$quote->getId();
+
+        $magentoQuoteBoldOrderRepository->saveStateAt($quoteId);
+
+        $checkoutSession->replaceQuote($quote);
+        $checkoutSession->setBoldCheckoutData(
+            [
+                'data' => [
+                    'public_order_id' => self::EXISTING_PUBLIC_ORDER_ID,
+                    'jwt_token' => 'stale-jwt-token',
+                ],
+            ]
+        );
+
+        /** @var ResumeOrder&MockObject $resumeOrder */
+        $resumeOrder = $this->createMock(ResumeOrder::class);
+        $resumeOrder
+            ->expects(self::never())
+            ->method('resume')
+            ->with(self::EXISTING_PUBLIC_ORDER_ID);
+
+        /** @var InitOrderFromQuote&MockObject $initOrderFromQuote */
+        $initOrderFromQuote = $this->createMock(InitOrderFromQuote::class);
+        $initOrderFromQuote
+            ->expects(self::once())
+            ->method('init')
+            ->with(self::identicalTo($quote))
+            ->willReturn(
+                [
+                    'data' => [
+                        'public_order_id' => self::NEW_PUBLIC_ORDER_ID,
+                        'jwt_token' => 'new-jwt-token',
+                        'flow_settings' => [],
+                    ],
+                ]
+            );
+
+        $this->registerCheckoutDataDependencies($objectManager, $resumeOrder, $initOrderFromQuote);
+
+        /** @var CheckoutData $checkoutData */
+        $checkoutData = $objectManager->create(CheckoutData::class);
+        $checkoutData->initCheckoutData();
+
+        self::assertNotSame(self::EXISTING_PUBLIC_ORDER_ID, $checkoutData->getPublicOrderId());
+        self::assertSame(self::NEW_PUBLIC_ORDER_ID, $checkoutData->getPublicOrderId());
+        self::assertSame('new-jwt-token', $checkoutData->getJwtToken());
+    }
+
+    /**
+     * @magentoConfigFixture current_website checkout/bold_checkout_payment_booster/shop_id test-shop-id
+     * @magentoConfigFixture current_website checkout/bold_checkout_payment_booster/is_payment_booster_enabled 1
+     * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/magento_quote_bold_order.php
+     */
+    public function testInitCheckoutDataResumesWhenQuoteNotProcessed(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var Quote $quote */
+        $quote = $objectManager->create(Quote::class);
+        /** @var QuoteResource $quoteResource */
+        $quoteResource = $objectManager->create(QuoteResource::class);
+        /** @var Session $checkoutSession */
+        $checkoutSession = $objectManager->get(Session::class);
+
+        $quoteResource->load($quote, 'test_order_item_with_items', 'reserved_order_id');
+        $websiteId = (int)$quote->getStore()->getWebsiteId();
+
+        $checkoutSession->replaceQuote($quote);
+        $checkoutSession->setBoldCheckoutData(
+            [
+                'data' => [
+                    'public_order_id' => self::EXISTING_PUBLIC_ORDER_ID,
+                    'jwt_token' => 'existing-jwt-token',
+                ],
+            ]
+        );
+
+        /** @var ResumeOrder&MockObject $resumeOrder */
+        $resumeOrder = $this->createMock(ResumeOrder::class);
+        $resumeOrder
+            ->expects(self::once())
+            ->method('resume')
+            ->with(self::EXISTING_PUBLIC_ORDER_ID, $websiteId)
+            ->willReturn(
+                [
+                    'data' => [
+                        'public_order_id' => self::EXISTING_PUBLIC_ORDER_ID,
+                        'jwt_token' => 'resumed-jwt-token',
+                    ],
+                ]
+            );
+
+        /** @var InitOrderFromQuote&MockObject $initOrderFromQuote */
+        $initOrderFromQuote = $this->createMock(InitOrderFromQuote::class);
+        $initOrderFromQuote->expects(self::never())->method('init');
+
+        $this->registerCheckoutDataDependencies($objectManager, $resumeOrder, $initOrderFromQuote);
+
+        /** @var CheckoutData $checkoutData */
+        $checkoutData = $objectManager->create(CheckoutData::class);
+        $checkoutData->initCheckoutData();
+
+        self::assertSame(self::EXISTING_PUBLIC_ORDER_ID, $checkoutData->getPublicOrderId());
+        self::assertSame('resumed-jwt-token', $checkoutData->getJwtToken());
+    }
+
+    /**
+     * @param \Magento\Framework\ObjectManagerInterface $objectManager
+     * @param ResumeOrder&MockObject $resumeOrder
+     * @param InitOrderFromQuote&MockObject $initOrderFromQuote
+     */
+    private function registerCheckoutDataDependencies(
+        $objectManager,
+        ResumeOrder $resumeOrder,
+        InitOrderFromQuote $initOrderFromQuote
+    ): void {
+        $getFastlaneStylesStub = $this->createStub(GetFastlaneStyles::class);
+        $getFastlaneStylesStub
+            ->method('getStyles')
+            ->willReturn([]);
+
+        $objectManager->configure(
+            [
+                ResumeOrder::class => [
+                    'shared' => true,
+                ],
+                InitOrderFromQuote::class => [
+                    'shared' => true,
+                ],
+                GetFastlaneStyles::class => [
+                    'shared' => true,
+                ],
+            ]
+        );
+        $objectManager->addSharedInstance($resumeOrder, ResumeOrder::class);
+        $objectManager->addSharedInstance($initOrderFromQuote, InitOrderFromQuote::class);
+        $objectManager->addSharedInstance($getFastlaneStylesStub, GetFastlaneStyles::class);
+    }
+}

--- a/Test/Integration/Model/SessionReuseTest.php
+++ b/Test/Integration/Model/SessionReuseTest.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\CheckoutPaymentBooster\Test\Integration\Model;
+
+use Bold\CheckoutPaymentBooster\Api\Data\Http\Client\ResultInterface;
+use Bold\CheckoutPaymentBooster\Api\MagentoQuoteBoldOrderRepositoryInterface;
+use Bold\CheckoutPaymentBooster\Model\CheckoutData;
+use Bold\CheckoutPaymentBooster\Model\Eps\GetFastlaneStyles;
+use Bold\CheckoutPaymentBooster\Model\Http\BoldClient;
+use Bold\CheckoutPaymentBooster\Model\InitOrderFromQuote;
+use Bold\CheckoutPaymentBooster\Model\Order\OrderExtensionData;
+use Bold\CheckoutPaymentBooster\Model\Order\OrderExtensionDataFactory;
+use Bold\CheckoutPaymentBooster\Model\Order\SetCompleteState;
+use Bold\CheckoutPaymentBooster\Model\OrderExtensionDataRepository;
+use Bold\CheckoutPaymentBooster\Model\ResumeOrder;
+use Magento\Checkout\Model\Session;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\ResourceModel\Quote as QuoteResource;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\ResourceModel\Order as OrderResource;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression tests for CHK-9605: reusing the same public_order_id on a completed DW quote.
+ *
+ * @magentoAppArea frontend
+ * @magentoAppIsolation enabled
+ */
+class SessionReuseTest extends TestCase
+{
+    private const STALE_PUBLIC_ORDER_ID = 'e5537d5a79264a53995b9ccf6b86225b46925006f6e24a59a8892fbb524b1aa0';
+
+    private const NEW_PUBLIC_ORDER_ID = 'aca5efca525f4748be5820d62d95c88b2e9b11b98bb643fc93b2109500a2f993';
+
+    /**
+     * Ozeparts smoking-gun path: order #1 completed, same quote reused, stale session ID must not resume.
+     *
+     * @magentoConfigFixture current_website checkout/bold_checkout_payment_booster/shop_id test-shop-id
+     * @magentoConfigFixture current_website checkout/bold_checkout_payment_booster/is_payment_booster_enabled 1
+     * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/magento_quote_bold_order.php
+     */
+    public function testSecondCheckoutReplacesStalePublicOrderIdOnProcessedQuote(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var Quote $quote */
+        $quote = $objectManager->create(Quote::class);
+        /** @var QuoteResource $quoteResource */
+        $quoteResource = $objectManager->create(QuoteResource::class);
+        /** @var Session $checkoutSession */
+        $checkoutSession = $objectManager->get(Session::class);
+        /** @var MagentoQuoteBoldOrderRepositoryInterface $magentoQuoteBoldOrderRepository */
+        $magentoQuoteBoldOrderRepository = $objectManager->create(MagentoQuoteBoldOrderRepositoryInterface::class);
+        /** @var CartRepositoryInterface $cartRepository */
+        $cartRepository = $objectManager->create(CartRepositoryInterface::class);
+
+        $quoteResource->load($quote, 'test_order_item_with_items', 'reserved_order_id');
+        $quoteId = (string)$quote->getId();
+
+        // Simulate order #1 order_complete: quote marked processed, bold_order_id cleared.
+        $magentoQuoteBoldOrderRepository->saveStateAt($quoteId);
+        $relation = $magentoQuoteBoldOrderRepository->getByQuoteId($quoteId);
+        $relation->setBoldOrderId('');
+        $magentoQuoteBoldOrderRepository->save($relation);
+
+        self::assertTrue($magentoQuoteBoldOrderRepository->isQuoteProcessed($quoteId));
+
+        // Stale Bold session from order #1 (the bug would resume this ID).
+        $checkoutSession->replaceQuote($quote);
+        $checkoutSession->setBoldCheckoutData(
+            [
+                'data' => [
+                    'public_order_id' => self::STALE_PUBLIC_ORDER_ID,
+                    'jwt_token' => 'stale-jwt-token',
+                ],
+            ]
+        );
+
+        /** @var ResumeOrder&MockObject $resumeOrder */
+        $resumeOrder = $this->createMock(ResumeOrder::class);
+        $resumeOrder
+            ->expects(self::never())
+            ->method('resume')
+            ->with(self::STALE_PUBLIC_ORDER_ID);
+
+        /** @var InitOrderFromQuote&MockObject $initOrderFromQuote */
+        $initOrderFromQuote = $this->createMock(InitOrderFromQuote::class);
+        $initOrderFromQuote
+            ->expects(self::once())
+            ->method('init')
+            ->with(self::identicalTo($quote))
+            ->willReturn(
+                [
+                    'data' => [
+                        'public_order_id' => self::NEW_PUBLIC_ORDER_ID,
+                        'jwt_token' => 'new-jwt-token',
+                        'flow_settings' => [],
+                    ],
+                ]
+            );
+
+        $this->registerCheckoutDataDependencies($objectManager, $resumeOrder, $initOrderFromQuote);
+
+        /** @var CheckoutData $checkoutData */
+        $checkoutData = $objectManager->create(CheckoutData::class);
+        $checkoutData->initCheckoutData();
+
+        self::assertNotSame(self::STALE_PUBLIC_ORDER_ID, $checkoutData->getPublicOrderId());
+        self::assertSame(self::NEW_PUBLIC_ORDER_ID, $checkoutData->getPublicOrderId());
+
+        $reloadedQuote = $cartRepository->get((int)$quoteId);
+        self::assertNull($reloadedQuote->getExtensionAttributes()->getBoldOrderId());
+    }
+
+    /**
+     * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/magento_quote_bold_order.php
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testOrderCompleteClearsBoldOrderIdOnQuoteRelation(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var Quote $quote */
+        $quote = $objectManager->create(Quote::class);
+        /** @var QuoteResource $quoteResource */
+        $quoteResource = $objectManager->create(QuoteResource::class);
+        /** @var Order $order */
+        $order = $objectManager->create(Order::class);
+        /** @var OrderResource $orderResource */
+        $orderResource = $objectManager->create(OrderResource::class);
+        /** @var OrderRepositoryInterface $orderRepository */
+        $orderRepository = $objectManager->get(OrderRepositoryInterface::class);
+        /** @var OrderExtensionDataFactory $orderExtensionDataFactory */
+        $orderExtensionDataFactory = $objectManager->get(OrderExtensionDataFactory::class);
+        /** @var OrderExtensionDataRepository $orderExtensionDataRepository */
+        $orderExtensionDataRepository = $objectManager->get(OrderExtensionDataRepository::class);
+        /** @var MagentoQuoteBoldOrderRepositoryInterface $magentoQuoteBoldOrderRepository */
+        $magentoQuoteBoldOrderRepository = $objectManager->create(MagentoQuoteBoldOrderRepositoryInterface::class);
+
+        $quoteResource->load($quote, 'test_order_item_with_items', 'reserved_order_id');
+        $quoteId = (string)$quote->getId();
+
+        $orderResource->load($order, '100000001', 'increment_id');
+        $order->setQuoteId($quote->getId());
+        $orderRepository->save($order);
+
+        /** @var OrderExtensionData $orderExtensionData */
+        $orderExtensionData = $orderExtensionDataFactory->create();
+        $orderExtensionData->setOrderId((int)$order->getEntityId());
+        $orderExtensionData->setPublicId(self::STALE_PUBLIC_ORDER_ID);
+        $orderExtensionDataRepository->save($orderExtensionData);
+
+        $boldApiResultMock = $this->createMock(ResultInterface::class);
+        $boldApiResultMock->method('getStatus')->willReturn(201);
+
+        /** @var BoldClient&MockObject $boldClientMock */
+        $boldClientMock = $this->createMock(BoldClient::class);
+        $boldClientMock
+            ->expects(self::once())
+            ->method('put')
+            ->willReturn($boldApiResultMock);
+
+        /** @var SetCompleteState $setCompleteState */
+        $setCompleteState = $objectManager->create(
+            SetCompleteState::class,
+            [
+                'client' => $boldClientMock,
+            ]
+        );
+        $setCompleteState->execute($order);
+
+        $relation = $magentoQuoteBoldOrderRepository->getByQuoteId($quoteId);
+        self::assertTrue($relation->isProcessed());
+        self::assertSame('', $relation->getBoldOrderId());
+        self::assertNotSame(self::STALE_PUBLIC_ORDER_ID, $relation->getBoldOrderId());
+    }
+
+    /**
+     * @magentoDataFixture Magento/Checkout/_files/quote_with_address.php
+     * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/digital_wallets_quote.php
+     */
+    public function testDigitalWalletQuotePreservationClearsStaleBoldSessionData(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var Quote $regularQuote */
+        $regularQuote = $objectManager->create(Quote::class);
+        /** @var Quote $digitalWalletsQuote */
+        $digitalWalletsQuote = $objectManager->create(Quote::class);
+        /** @var QuoteResource $quoteResource */
+        $quoteResource = $objectManager->create(QuoteResource::class);
+        /** @var Session $checkoutSession */
+        $checkoutSession = $objectManager->get(Session::class);
+
+        $quoteResource->load($regularQuote, 'test_order_1', 'reserved_order_id');
+        $quoteResource->load($digitalWalletsQuote, 'digital_wallets_order_1', 'reserved_order_id');
+
+        $checkoutSession->replaceQuote($regularQuote);
+        $checkoutSession->setLastQuoteId($digitalWalletsQuote->getId());
+        $checkoutSession->setBoldCheckoutData(
+            [
+                'data' => [
+                    'public_order_id' => self::STALE_PUBLIC_ORDER_ID,
+                    'jwt_token' => 'stale-jwt-token',
+                ],
+            ]
+        );
+
+        $checkoutSession->clearQuote();
+
+        self::assertTrue($checkoutSession->hasQuote());
+        self::assertNull($checkoutSession->getBoldCheckoutData());
+    }
+
+    /**
+     * @param \Magento\Framework\ObjectManagerInterface $objectManager
+     * @param ResumeOrder&MockObject $resumeOrder
+     * @param InitOrderFromQuote&MockObject $initOrderFromQuote
+     */
+    private function registerCheckoutDataDependencies(
+        $objectManager,
+        ResumeOrder $resumeOrder,
+        InitOrderFromQuote $initOrderFromQuote
+    ): void {
+        $getFastlaneStylesStub = $this->createStub(GetFastlaneStyles::class);
+        $getFastlaneStylesStub
+            ->method('getStyles')
+            ->willReturn([]);
+
+        $objectManager->configure(
+            [
+                ResumeOrder::class => [
+                    'shared' => true,
+                ],
+                InitOrderFromQuote::class => [
+                    'shared' => true,
+                ],
+                GetFastlaneStyles::class => [
+                    'shared' => true,
+                ],
+            ]
+        );
+        $objectManager->addSharedInstance($resumeOrder, ResumeOrder::class);
+        $objectManager->addSharedInstance($initOrderFromQuote, InitOrderFromQuote::class);
+        $objectManager->addSharedInstance($getFastlaneStylesStub, GetFastlaneStyles::class);
+    }
+}

--- a/Test/Integration/Plugin/Checkout/Model/SessionPluginTest.php
+++ b/Test/Integration/Plugin/Checkout/Model/SessionPluginTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Bold\CheckoutPaymentBooster\Test\Integration\Plugin\Checkout\Model;
 
+use Bold\CheckoutPaymentBooster\Model\CheckoutData;
 use Bold\CheckoutPaymentBooster\Plugin\Checkout\Model\SessionPlugin;
 use Bold\CheckoutPaymentBooster\Test\Integration\_Assertions\AssertPluginIsConfiguredCorrectly;
 use Magento\Checkout\Model\Session;
@@ -35,7 +36,21 @@ class SessionPluginTest extends TestCase
      */
     public function testDoesNotClearSessionIfLastQuoteIsDigitalWalletsQuote(): void
     {
+        $checkoutDataMock = $this->createMock(CheckoutData::class);
+        $checkoutDataMock
+            ->expects(self::once())
+            ->method('resetCheckoutData');
+
         $objectManager = Bootstrap::getObjectManager();
+        $objectManager->configure(
+            [
+                CheckoutData::class => [
+                    'shared' => true,
+                ],
+            ]
+        );
+        $objectManager->addSharedInstance($checkoutDataMock, CheckoutData::class);
+
         /** @var Quote $regularQuote */
         $regularQuote = $objectManager->create(Quote::class);
         /** @var Quote $digitalWalletsQuote */

--- a/Test/Integration/Plugin/Quote/Api/CartRepositoryInterfacePluginTest.php
+++ b/Test/Integration/Plugin/Quote/Api/CartRepositoryInterfacePluginTest.php
@@ -110,4 +110,35 @@ class CartRepositoryInterfacePluginTest extends TestCase
             $magentoQuoteBoldOrder->getBoldOrderId()
         );
     }
+
+    /**
+     * @magentoAppArea frontend
+     * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/magento_quote_bold_order.php
+     * @throws NoSuchEntityException
+     */
+    public function testDoesNotExposeClearedBoldOrderIdAfterCartRetrieval(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var MagentoQuoteBoldOrder $magentoQuoteBoldOrder */
+        $magentoQuoteBoldOrder = $objectManager->create(MagentoQuoteBoldOrder::class);
+        /** @var MagentoQuoteBoldOrderResourceModel $magentoQuoteBoldOrderResourceModel */
+        $magentoQuoteBoldOrderResourceModel = $objectManager->create(MagentoQuoteBoldOrderResourceModel::class);
+        /** @var MagentoQuoteBoldOrderRepositoryInterface $magentoQuoteBoldOrderRepository */
+        $magentoQuoteBoldOrderRepository = $objectManager->create(MagentoQuoteBoldOrderRepositoryInterface::class);
+        /** @var CartRepositoryInterface $cartRepository */
+        $cartRepository = $objectManager->create(CartRepositoryInterface::class);
+
+        $magentoQuoteBoldOrderResourceModel->load(
+            $magentoQuoteBoldOrder,
+            'e5537d5a79264a53995b9ccf6b86225b46925006f6e24a59a8892fbb524b1aa0',
+            'bold_order_id'
+        );
+
+        $magentoQuoteBoldOrder->setBoldOrderId('');
+        $magentoQuoteBoldOrderRepository->save($magentoQuoteBoldOrder);
+
+        $cart = $cartRepository->get((int)$magentoQuoteBoldOrder->getQuoteId());
+
+        self::assertNull($cart->getExtensionAttributes()->getBoldOrderId());
+    }
 }


### PR DESCRIPTION
Prevent resuming a completed public_order_id when the same DW quote is reused for a second order, which caused split PayPal auths and BAC reconciliation failures.
- Skip /resume in CheckoutData when isQuoteProcessed() is true
- Clear bold_order_id after order_complete and ignore empty values in CartRepository
- Reset Bold checkout session when SessionPlugin preserves a digital wallet quote
- Add integration tests for the new guards