### PR TITLE
CHK-9612 — Release 2.7.4

### DIFF
--- a/.github/workflows/pull-request-integration-tests-job.yml
+++ b/.github/workflows/pull-request-integration-tests-job.yml
@@ -56,7 +56,7 @@ jobs:
             composer-version: "v2"
             maria-db-version: "10.6"
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
     services:
       mariadb:
         image: mariadb:${{ matrix.maria-db-version }}
@@ -99,17 +99,14 @@ jobs:
       - name: Setup problem matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-      #      - name: Cache Composer packages
-      #        id: composer-cache
-      #        uses: actions/cache@v4
-      #        with:
-      #          path: integration-pipeline-test/vendor
-      #          key: ${{ runner.os }}-php-${{ matrix.php-version }}-magento-${{ matrix.magento-version }}
-
-      #      - name: clear composer cache prevent deps issue
-      #        working-directory: integration-pipeline-test
-      #        run: |
-      #          rm -rf ~/.composer
+      - name: Cache Composer packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache
+          key: ${{ runner.os }}-composer-${{ matrix.php-version }}-magento-${{ matrix.magento-version }}
+          restore-keys: |
+            ${{ runner.os }}-composer-${{ matrix.php-version }}-
+            ${{ runner.os }}-composer-
 
       - name: add-credentials
         working-directory: integration-pipeline-test
@@ -192,10 +189,26 @@ jobs:
             composer require --no-update "sebastian/comparator:^4.0"
           fi
 
-          composer config repositories.adobe-commerce-bold-checkout-payment-booster vcs git@github.com:bold-commerce/adobe-commerce-bold-checkout-payment-booster.git
-          composer require bold-commerce/module-checkout-payment-booster:dev-${{ github.head_ref || github.ref_name }} --no-scripts --no-update
-          composer install --prefer-dist --no-progress $COMPOSER_NO_BLOCK_ARGS
-          composer require --dev dms/phpunit-arraysubset-asserts --no-scripts $COMPOSER_NO_BLOCK_ARGS
+          # Use the already-checked-out repo via path to avoid GitHub API 429 throttling on VCS dev aliases.
+          composer config repositories.adobe-commerce-bold-checkout-payment-booster path ..
+          composer require bold-commerce/module-checkout-payment-booster:@dev --no-scripts --no-update
+          if [ "${{ matrix.php-version }}" = "8.1" ] || \
+             [ "${{ matrix.magento-version }}" = "2.4.6-p10" ] || \
+             [ "${{ matrix.magento-version }}" = "2.4.7-p5" ]; then
+            composer require --dev dms/phpunit-arraysubset-asserts:^0.5 phpunit/phpunit:^9.5 --no-scripts --no-update
+          else
+            composer require --dev dms/phpunit-arraysubset-asserts:^0.5 phpunit/phpunit:^10.5 --no-scripts --no-update
+          fi
+
+          for attempt in 1 2 3; do
+            composer install --prefer-dist --no-progress $COMPOSER_NO_BLOCK_ARGS && break
+            if [ "$attempt" -eq 3 ]; then
+              echo "composer install failed after 3 attempts"
+              exit 1
+            fi
+            echo "composer install attempt $attempt failed (likely GitHub API 429), retrying in 30s..."
+            sleep 30
+          done
 
       - name: install-php8-deps
         if: matrix.php-version >= '8'
@@ -216,6 +229,7 @@ jobs:
           mysql -h 127.0.0.1 -u root -proot -e "CREATE DATABASE magento_integration_tests;"
 
       - name: run the test
+        timeout-minutes: 35
         working-directory: integration-pipeline-test
         run: |
           vendor/bin/phpunit \

--- a/Model/CheckoutData.php
+++ b/Model/CheckoutData.php
@@ -116,22 +116,27 @@ class CheckoutData
 
         $existingPublicOrderId = $this->getPublicOrderId();
         $quoteId = (string)$quote->getId();
+        $quoteIsProcessed = $this->magentoQuoteBoldOrderRepository->isQuoteProcessed($quoteId);
 
         $this->orderTracker->trace($websiteId, 'init_checkout_data_start', [
             'quote_id' => $quoteId,
             'customer_id' => $quote->getCustomerId(),
             'session_public_order_id' => $existingPublicOrderId,
-            'quote_processed' => $this->magentoQuoteBoldOrderRepository->isQuoteProcessed($quoteId),
+            'quote_processed' => $quoteIsProcessed,
         ]);
 
         if ($existingPublicOrderId) {
-            if ($this->magentoQuoteBoldOrderRepository->isQuoteProcessed($quoteId)) {
+            if ($quoteIsProcessed) {
                 $this->orderTracker->trace($websiteId, 'init_checkout_data_reset', [
                     'quote_id' => $quoteId,
                     'stale_public_order_id' => $existingPublicOrderId,
                     'reason' => 'quote_already_processed',
                 ]);
                 $this->resetCheckoutData();
+                $extensionAttributes = $quote->getExtensionAttributes();
+                if ($extensionAttributes !== null) {
+                    $extensionAttributes->setBoldOrderId('');
+                }
                 $existingPublicOrderId = null;
             }
         }
@@ -159,7 +164,7 @@ class CheckoutData
         }
         $checkoutData = $this->initOrderFromQuote->init($quote);
         $newPublicOrderId = $checkoutData['data']['public_order_id'] ?? null;
-        if ($newPublicOrderId) {
+        if ($newPublicOrderId && !$quoteIsProcessed) {
             $this->syncPublicOrderIdForQuote->execute($newPublicOrderId, $quoteId, $quote);
         }
         $this->orderTracker->trace($websiteId, 'init_checkout_data_new_order', [

--- a/Model/CheckoutData.php
+++ b/Model/CheckoutData.php
@@ -8,7 +8,6 @@ use Bold\CheckoutPaymentBooster\Api\MagentoQuoteBoldOrderRepositoryInterface;
 use Bold\CheckoutPaymentBooster\Model\Eps\GetFastlaneStyles;
 use Bold\CheckoutPaymentBooster\Model\Log\OrderTracker;
 use Bold\CheckoutPaymentBooster\Model\Order\SyncPublicOrderIdForQuote;
-use Exception;
 use Magento\Checkout\Model\Session;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Quote\Api\Data\CartInterface;
@@ -64,18 +63,12 @@ class CheckoutData
     private $orderTracker;
 
     /**
-     * @var MagentoQuoteBoldOrderRepositoryInterface
-     */
-    private $magentoQuoteBoldOrderRepository;
-
-    /**
      * @param Session $checkoutSession
      * @param IsPaymentBoosterAvailable $isPaymentBoosterAvailable
      * @param InitOrderFromQuote $initOrderFromQuote
      * @param ResumeOrder $resumeOrder
      * @param GetFastlaneStyles $getFastlaneStyles
      * @param Config $config
-     * @param MagentoQuoteBoldOrderRepositoryInterface $magentoQuoteBoldOrderRepository
      * @param MagentoQuoteBoldOrderRepositoryInterface $magentoQuoteBoldOrderRepository
      * @param SyncPublicOrderIdForQuote $syncPublicOrderIdForQuote
      * @param OrderTracker $orderTracker
@@ -122,18 +115,6 @@ class CheckoutData
         }
 
         $existingPublicOrderId = $this->getPublicOrderId();
-
-        if ($existingPublicOrderId) {
-            $quoteId = (string)$quote->getId();
-            if ($this->magentoQuoteBoldOrderRepository->isQuoteProcessed($quoteId)) {
-                $this->resetCheckoutData();
-                $existingPublicOrderId = null;
-            }
-        }
-
-        if ($existingPublicOrderId) {
-
-        $existingPublicOrderId = $this->getPublicOrderId();
         $quoteId = (string)$quote->getId();
 
         $this->orderTracker->trace($websiteId, 'init_checkout_data_start', [
@@ -157,7 +138,7 @@ class CheckoutData
 
         if ($existingPublicOrderId) {
             $orderData = $this->resumeOrder->resume(
-                $this->getPublicOrderId(),
+                $existingPublicOrderId,
                 $websiteId
             );
             if ($orderData) {

--- a/Model/CheckoutData.php
+++ b/Model/CheckoutData.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Bold\CheckoutPaymentBooster\Model;
 
+use Bold\CheckoutPaymentBooster\Api\MagentoQuoteBoldOrderRepositoryInterface;
 use Bold\CheckoutPaymentBooster\Model\Eps\GetFastlaneStyles;
 use Exception;
 use Magento\Checkout\Model\Session;
@@ -46,12 +47,18 @@ class CheckoutData
     private $config;
 
     /**
+     * @var MagentoQuoteBoldOrderRepositoryInterface
+     */
+    private $magentoQuoteBoldOrderRepository;
+
+    /**
      * @param Session $checkoutSession
      * @param IsPaymentBoosterAvailable $isPaymentBoosterAvailable
      * @param InitOrderFromQuote $initOrderFromQuote
      * @param ResumeOrder $resumeOrder
      * @param GetFastlaneStyles $getFastlaneStyles
      * @param Config $config
+     * @param MagentoQuoteBoldOrderRepositoryInterface $magentoQuoteBoldOrderRepository
      */
     public function __construct(
         Session $checkoutSession,
@@ -59,7 +66,8 @@ class CheckoutData
         InitOrderFromQuote $initOrderFromQuote,
         ResumeOrder $resumeOrder,
         GetFastlaneStyles $getFastlaneStyles,
-        Config $config
+        Config $config,
+        MagentoQuoteBoldOrderRepositoryInterface $magentoQuoteBoldOrderRepository
     ) {
         $this->checkoutSession = $checkoutSession;
         $this->isPaymentBoosterAvailable = $isPaymentBoosterAvailable;
@@ -67,6 +75,7 @@ class CheckoutData
         $this->resumeOrder = $resumeOrder;
         $this->getFastlaneStyles = $getFastlaneStyles;
         $this->config = $config;
+        $this->magentoQuoteBoldOrderRepository = $magentoQuoteBoldOrderRepository;
     }
 
     /**
@@ -87,9 +96,20 @@ class CheckoutData
         if (!$this->isPaymentBoosterAvailable->isAvailable()) {
             return;
         }
-        if ($this->getPublicOrderId()) {
+
+        $existingPublicOrderId = $this->getPublicOrderId();
+
+        if ($existingPublicOrderId) {
+            $quoteId = (string)$quote->getId();
+            if ($this->magentoQuoteBoldOrderRepository->isQuoteProcessed($quoteId)) {
+                $this->resetCheckoutData();
+                $existingPublicOrderId = null;
+            }
+        }
+
+        if ($existingPublicOrderId) {
             $orderData = $this->resumeOrder->resume(
-                $this->getPublicOrderId(),
+                $existingPublicOrderId,
                 $websiteId
             );
             if ($orderData) {

--- a/Model/CheckoutData.php
+++ b/Model/CheckoutData.php
@@ -6,6 +6,8 @@ namespace Bold\CheckoutPaymentBooster\Model;
 
 use Bold\CheckoutPaymentBooster\Api\MagentoQuoteBoldOrderRepositoryInterface;
 use Bold\CheckoutPaymentBooster\Model\Eps\GetFastlaneStyles;
+use Bold\CheckoutPaymentBooster\Model\Log\OrderTracker;
+use Bold\CheckoutPaymentBooster\Model\Order\SyncPublicOrderIdForQuote;
 use Exception;
 use Magento\Checkout\Model\Session;
 use Magento\Framework\Exception\LocalizedException;
@@ -52,6 +54,16 @@ class CheckoutData
     private $magentoQuoteBoldOrderRepository;
 
     /**
+     * @var SyncPublicOrderIdForQuote
+     */
+    private $syncPublicOrderIdForQuote;
+
+    /**
+     * @var OrderTracker
+     */
+    private $orderTracker;
+
+    /**
      * @param Session $checkoutSession
      * @param IsPaymentBoosterAvailable $isPaymentBoosterAvailable
      * @param InitOrderFromQuote $initOrderFromQuote
@@ -59,6 +71,8 @@ class CheckoutData
      * @param GetFastlaneStyles $getFastlaneStyles
      * @param Config $config
      * @param MagentoQuoteBoldOrderRepositoryInterface $magentoQuoteBoldOrderRepository
+     * @param SyncPublicOrderIdForQuote $syncPublicOrderIdForQuote
+     * @param OrderTracker $orderTracker
      */
     public function __construct(
         Session $checkoutSession,
@@ -67,7 +81,9 @@ class CheckoutData
         ResumeOrder $resumeOrder,
         GetFastlaneStyles $getFastlaneStyles,
         Config $config,
-        MagentoQuoteBoldOrderRepositoryInterface $magentoQuoteBoldOrderRepository
+        MagentoQuoteBoldOrderRepositoryInterface $magentoQuoteBoldOrderRepository,
+        SyncPublicOrderIdForQuote $syncPublicOrderIdForQuote,
+        OrderTracker $orderTracker
     ) {
         $this->checkoutSession = $checkoutSession;
         $this->isPaymentBoosterAvailable = $isPaymentBoosterAvailable;
@@ -76,6 +92,8 @@ class CheckoutData
         $this->getFastlaneStyles = $getFastlaneStyles;
         $this->config = $config;
         $this->magentoQuoteBoldOrderRepository = $magentoQuoteBoldOrderRepository;
+        $this->syncPublicOrderIdForQuote = $syncPublicOrderIdForQuote;
+        $this->orderTracker = $orderTracker;
     }
 
     /**
@@ -98,10 +116,22 @@ class CheckoutData
         }
 
         $existingPublicOrderId = $this->getPublicOrderId();
+        $quoteId = (string)$quote->getId();
+
+        $this->orderTracker->trace($websiteId, 'init_checkout_data_start', [
+            'quote_id' => $quoteId,
+            'customer_id' => $quote->getCustomerId(),
+            'session_public_order_id' => $existingPublicOrderId,
+            'quote_processed' => $this->magentoQuoteBoldOrderRepository->isQuoteProcessed($quoteId),
+        ]);
 
         if ($existingPublicOrderId) {
-            $quoteId = (string)$quote->getId();
             if ($this->magentoQuoteBoldOrderRepository->isQuoteProcessed($quoteId)) {
+                $this->orderTracker->trace($websiteId, 'init_checkout_data_reset', [
+                    'quote_id' => $quoteId,
+                    'stale_public_order_id' => $existingPublicOrderId,
+                    'reason' => 'quote_already_processed',
+                ]);
                 $this->resetCheckoutData();
                 $existingPublicOrderId = null;
             }
@@ -113,13 +143,31 @@ class CheckoutData
                 $websiteId
             );
             if ($orderData) {
+                $this->orderTracker->trace($websiteId, 'init_checkout_data_resumed', [
+                    'quote_id' => $quoteId,
+                    'public_order_id' => $existingPublicOrderId,
+                ]);
+                $this->syncPublicOrderIdForQuote->execute($existingPublicOrderId, $quoteId, $quote);
                 $checkoutData = $this->checkoutSession->getBoldCheckoutData();
                 $checkoutData['data']['jwt_token'] = $orderData['data']['jwt_token'];
                 $this->checkoutSession->setBoldCheckoutData($checkoutData);
                 return;
             }
+            $this->orderTracker->trace($websiteId, 'init_checkout_data_resume_failed', [
+                'quote_id' => $quoteId,
+                'public_order_id' => $existingPublicOrderId,
+            ]);
         }
         $checkoutData = $this->initOrderFromQuote->init($quote);
+        $newPublicOrderId = $checkoutData['data']['public_order_id'] ?? null;
+        if ($newPublicOrderId) {
+            $this->syncPublicOrderIdForQuote->execute($newPublicOrderId, $quoteId, $quote);
+        }
+        $this->orderTracker->trace($websiteId, 'init_checkout_data_new_order', [
+            'quote_id' => $quoteId,
+            'public_order_id' => $newPublicOrderId,
+            'previous_session_public_order_id' => $existingPublicOrderId,
+        ]);
         $checkoutData['data']['flow_settings']['fastlane_styles'] = $this->getFastlaneStyles->getStyles(
             $websiteId,
             $quote->getStore()->getBaseUrl()

--- a/Model/Log/OrderTracker.php
+++ b/Model/Log/OrderTracker.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\CheckoutPaymentBooster\Model\Log;
+
+use Bold\CheckoutPaymentBooster\Model\Config;
+use Magento\Framework\Serialize\Serializer\Json;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Structured trace logger for Bold public order ID resolution and payment lifecycle.
+ *
+ * Writes to var/log/bold_checkout_payment_booster.log when advanced logging is enabled — grep for [OrderTracker].
+ */
+class OrderTracker
+{
+    private const PREFIX = '[OrderTracker]';
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var Config
+     */
+    private $config;
+
+    /**
+     * @var Json
+     */
+    private $json;
+
+    /**
+     * @param LoggerInterface $logger
+     * @param Config $config
+     * @param Json $json
+     */
+    public function __construct(LoggerInterface $logger, Config $config, Json $json)
+    {
+        $this->logger = $logger;
+        $this->config = $config;
+        $this->json = $json;
+    }
+
+    /**
+     * @param int $websiteId
+     * @param string $event
+     * @param array<string, mixed> $context
+     * @return void
+     */
+    public function trace(int $websiteId, string $event, array $context = []): void
+    {
+        if (!$this->config->getLogIsEnabled($websiteId)) {
+            return;
+        }
+
+        $this->logger->info(self::PREFIX . ' ' . $event . ' ' . $this->json->serialize($context));
+    }
+}

--- a/Model/Log/OrderTracker.php
+++ b/Model/Log/OrderTracker.php
@@ -11,11 +11,29 @@ use Psr\Log\LoggerInterface;
 /**
  * Structured trace logger for Bold public order ID resolution and payment lifecycle.
  *
- * Writes to var/log/bold_checkout_payment_booster.log when advanced logging is enabled — grep for [OrderTracker].
+ * Writes to var/log/bold_checkout_payment_booster.log when advanced logging is enabled.
+ * Grep for [OrderTracker] or a public_order_id value to follow a checkout.
+ *
+ * Correlation:
+ * - public_order_id (and session/quote/db variants) — logged in full for Bold order tracing
+ * - checkout_ref — stable hash per Magento quote_id; links events on the same cart
+ * - txn_ref / bold_order_ref — hashed payment identifiers
  */
 class OrderTracker
 {
     private const PREFIX = '[OrderTracker]';
+
+    private const REF_LENGTH = 12;
+
+    /**
+     * @var string[]
+     */
+    private const DROP_KEYS = [
+        'grand_total',
+        'order_total_cents',
+        'url',
+        'website_id',
+    ];
 
     /**
      * @var LoggerInterface
@@ -56,6 +74,90 @@ class OrderTracker
             return;
         }
 
-        $this->logger->info(self::PREFIX . ' ' . $event . ' ' . $this->json->serialize($context));
+        $sanitized = $this->sanitizeContext($context);
+        $sanitized['website_id'] = $websiteId;
+
+        $this->logger->info(self::PREFIX . ' ' . $event . ' ' . $this->json->serialize($sanitized));
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     * @return array<string, mixed>
+     */
+    private function sanitizeContext(array $context): array
+    {
+        $out = [];
+
+        if (isset($context['quote_id']) && $context['quote_id'] !== '' && $context['quote_id'] !== null) {
+            $out['checkout_ref'] = $this->reference((string)$context['quote_id'], 'quote');
+        }
+
+        foreach ($context as $key => $value) {
+            if (in_array($key, self::DROP_KEYS, true)) {
+                continue;
+            }
+
+            if ($key === 'quote_id') {
+                $out['quote_id'] = (string)$value;
+                continue;
+            }
+
+            if ($key === 'customer_id') {
+                $out['customer_logged_in'] = $value !== null && $value !== '' && (int)$value > 0;
+                continue;
+            }
+
+            if ($key === 'transaction_id') {
+                if ($value !== null && $value !== '') {
+                    $out['txn_ref'] = $this->reference((string)$value, 'txn');
+                }
+                continue;
+            }
+
+            if ($key === 'bold_order_id') {
+                if ($value !== null && $value !== '') {
+                    $out['bold_order_ref'] = $this->reference((string)$value, 'bold_order');
+                }
+                continue;
+            }
+
+            if ($key === 'errors') {
+                $out['error_messages'] = $this->sanitizeErrors($value);
+                continue;
+            }
+
+            if (is_scalar($value) || $value === null) {
+                $out[$key] = $value;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param mixed $errors
+     * @return string[]
+     */
+    private function sanitizeErrors($errors): array
+    {
+        if (!is_array($errors)) {
+            return [];
+        }
+
+        $messages = [];
+        foreach ($errors as $error) {
+            if (is_array($error) && isset($error['message'])) {
+                $messages[] = (string)$error['message'];
+            } elseif (is_string($error)) {
+                $messages[] = $error;
+            }
+        }
+
+        return $messages;
+    }
+
+    private function reference(string $value, string $namespace): string
+    {
+        return substr(hash('sha256', $namespace . ':' . $value), 0, self::REF_LENGTH);
     }
 }

--- a/Model/Order/HydrateOrderFromQuote.php
+++ b/Model/Order/HydrateOrderFromQuote.php
@@ -6,6 +6,7 @@ namespace Bold\CheckoutPaymentBooster\Model\Order;
 
 use Bold\CheckoutPaymentBooster\Api\MagentoQuoteBoldOrderRepositoryInterface;
 use Bold\CheckoutPaymentBooster\Model\Http\BoldClient;
+use Bold\CheckoutPaymentBooster\Model\Log\OrderTracker;
 use Bold\CheckoutPaymentBooster\Model\Order\Address\Converter;
 use Bold\CheckoutPaymentBooster\Model\Quote\GetCartLineItems;
 use Magento\Catalog\Api\ProductRepositoryInterface;
@@ -56,24 +57,32 @@ class HydrateOrderFromQuote
     private $magentoQuoteBoldOrderRepository;
 
     /**
+     * @var OrderTracker
+     */
+    private $orderTracker;
+
+    /**
      * @param BoldClient $client
      * @param GetCartLineItems $getCartLineItems
      * @param Converter $addressConverter
      * @param ToOrderAddress $quoteToOrderAddressConverter
      * @param MagentoQuoteBoldOrderRepositoryInterface $magentoQuoteBoldOrderRepository
+     * @param OrderTracker $orderTracker
      */
     public function __construct(
         BoldClient $client,
         GetCartLineItems $getCartLineItems,
         Converter $addressConverter,
         ToOrderAddress $quoteToOrderAddressConverter,
-        MagentoQuoteBoldOrderRepositoryInterface $magentoQuoteBoldOrderRepository
+        MagentoQuoteBoldOrderRepositoryInterface $magentoQuoteBoldOrderRepository,
+        OrderTracker $orderTracker
     ) {
         $this->client = $client;
         $this->getCartLineItems = $getCartLineItems;
         $this->addressConverter = $addressConverter;
         $this->quoteToOrderAddressConverter = $quoteToOrderAddressConverter;
         $this->magentoQuoteBoldOrderRepository = $magentoQuoteBoldOrderRepository;
+        $this->orderTracker = $orderTracker;
     }
 
     /**
@@ -152,11 +161,31 @@ class HydrateOrderFromQuote
         }
 
         $url = sprintf(self::HYDRATE_ORDER_URL, $publicOrderId);
+        $this->orderTracker->trace($websiteId, 'hydrate_start', [
+            'public_order_id' => $publicOrderId,
+            'quote_id' => $quote->getId(),
+            'customer_id' => $quote->getCustomerId(),
+            'grand_total' => $quote->getGrandTotal(),
+            'order_total_cents' => $body['totals']['order_total'],
+            'currency' => $quote->getQuoteCurrencyCode(),
+        ]);
         $hydrateResponse = $this->client->put($websiteId, $url, $body);
 
         if ($hydrateResponse->getStatus() !== 201) {
+            $this->orderTracker->trace($websiteId, 'hydrate_failed', [
+                'public_order_id' => $publicOrderId,
+                'quote_id' => $quote->getId(),
+                'http_status' => $hydrateResponse->getStatus(),
+                'errors' => $hydrateResponse->getErrors(),
+            ]);
             throw new LocalizedException(__('Failed to hydrate order with id="%1"', $publicOrderId));
         }
+
+        $this->orderTracker->trace($websiteId, 'hydrate_success', [
+            'public_order_id' => $publicOrderId,
+            'quote_id' => $quote->getId(),
+            'order_total_cents' => $body['totals']['order_total'],
+        ]);
 
         $this->magentoQuoteBoldOrderRepository->saveHydratedAt((string) $quote->getId());
     }

--- a/Model/Order/HydrateOrderFromQuote.php
+++ b/Model/Order/HydrateOrderFromQuote.php
@@ -7,14 +7,15 @@ namespace Bold\CheckoutPaymentBooster\Model\Order;
 use Bold\CheckoutPaymentBooster\Api\MagentoQuoteBoldOrderRepositoryInterface;
 use Bold\CheckoutPaymentBooster\Model\Http\BoldClient;
 use Bold\CheckoutPaymentBooster\Model\Order\Address\Converter;
+use Bold\CheckoutPaymentBooster\Model\Quote\BoldQuoteAmounts;
 use Bold\CheckoutPaymentBooster\Model\Quote\GetCartLineItems;
-use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Customer\Api\Data\CustomerInterface;
 use Magento\Customer\Model\Customer;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Quote\Api\Data\CartInterface;
 use Magento\Quote\Model\Quote;
 use Magento\Quote\Model\Quote\Address\ToOrderAddress;
+use Magento\Quote\Model\Quote\Address\Total;
 use Magento\Sales\Api\Data\OrderAddressInterface;
 use Magento\Sales\Model\Order\Address;
 
@@ -56,24 +57,32 @@ class HydrateOrderFromQuote
     private $magentoQuoteBoldOrderRepository;
 
     /**
+     * @var BoldQuoteAmounts
+     */
+    private $boldQuoteAmounts;
+
+    /**
      * @param BoldClient $client
      * @param GetCartLineItems $getCartLineItems
      * @param Converter $addressConverter
      * @param ToOrderAddress $quoteToOrderAddressConverter
      * @param MagentoQuoteBoldOrderRepositoryInterface $magentoQuoteBoldOrderRepository
+     * @param BoldQuoteAmounts $boldQuoteAmounts
      */
     public function __construct(
         BoldClient $client,
         GetCartLineItems $getCartLineItems,
         Converter $addressConverter,
         ToOrderAddress $quoteToOrderAddressConverter,
-        MagentoQuoteBoldOrderRepositoryInterface $magentoQuoteBoldOrderRepository
+        MagentoQuoteBoldOrderRepositoryInterface $magentoQuoteBoldOrderRepository,
+        BoldQuoteAmounts $boldQuoteAmounts
     ) {
         $this->client = $client;
         $this->getCartLineItems = $getCartLineItems;
         $this->addressConverter = $addressConverter;
         $this->quoteToOrderAddressConverter = $quoteToOrderAddressConverter;
         $this->magentoQuoteBoldOrderRepository = $magentoQuoteBoldOrderRepository;
+        $this->boldQuoteAmounts = $boldQuoteAmounts;
     }
 
     /**
@@ -102,34 +111,31 @@ class HydrateOrderFromQuote
             $shippingDescription = $quote->getShippingAddress()->getShippingDescription();
         }
 
-        [$fees, $discounts] = $this->getFeesAndDiscounts($totals);
+        [$fees, $discounts] = $this->getFeesAndDiscounts($quote, $totals);
         $discountTotal = array_reduce($discounts, function (?float $sum, $discountLine) {
             return $sum + $discountLine['value'];
         });
 
         $cartItems = $this->getCartLineItems->getItems($quote);
         $formattedCartItems = $this->formatCartItems($cartItems);
-        $subtotal = $totals['subtotal']['value_excl_tax'] ?? $totals['subtotal']['value'];
-        $shippingTotal = $totals['shipping']['value'] ?? 0;
-        $shippingTotalNoTax = $totals['shipping']['value_excl_tax'] ?? $shippingTotal;
-        $grandTotal = $totals['grand_total']['value_incl_tax'] ?? $totals['grand_total']['value'];
+        $taxFullInfo = isset($totals['tax']) ? ($totals['tax']['full_info'] ?? []) : [];
         $body = [
             'billing_address' => $this->addressConverter->convert($billingAddress),
             'shipping_address' => $this->addressConverter->convert($shippingAddress),
             'cart_items' => $formattedCartItems,
-            'taxes' => $this->getTaxLines($totals['tax']['full_info']),
+            'taxes' => $this->getTaxLines($taxFullInfo),
             'discounts' => $discounts,
             'fees' => $fees,
             'shipping_line' => [
                 'rate_name' => $shippingDescription ?? '',
-                'cost' => $this->convertToCents((float)$shippingTotalNoTax),
+                'cost' => $this->convertToCents($this->boldQuoteAmounts->getShippingAmount($quote)),
             ],
             'totals' => [
-                'sub_total' => $this->convertToCents((float)$subtotal),
-                'tax_total' => $this->convertToCents($totals['tax']['value']),
+                'sub_total' => $this->convertToCents($this->boldQuoteAmounts->getSubtotal($quote)),
+                'tax_total' => $this->convertToCents($this->boldQuoteAmounts->getTaxAmount($quote)),
                 'discount_total' => $discountTotal ?? 0,
-                'shipping_total' => $this->convertToCents((float)$shippingTotalNoTax),
-                'order_total' => $this->convertToCents((float)$grandTotal),
+                'shipping_total' => $this->convertToCents($this->boldQuoteAmounts->getShippingAmount($quote)),
+                'order_total' => $this->convertToCents($this->boldQuoteAmounts->getGrandTotal($quote)),
             ],
         ];
         /** @var CustomerInterface&Customer $customer */
@@ -195,37 +201,49 @@ class HydrateOrderFromQuote
     /**
      * Looks at total segments and makes unrecognized segments into fees and discounts
      *
-     * @param array<string, array{code: string, value: float, title: string}> $totals
+     * @param Quote $quote
+     * @param array<string, Total> $totals
      * @return array{line_text?: string, description?: string, value: float}[][]
      */
-    private function getFeesAndDiscounts(array $totals): array
+    private function getFeesAndDiscounts(Quote $quote, array $totals): array
     {
         $fees = [];
         $discounts = [];
 
         if (isset($totals['discount'])) {
-            $discounts[] = [
-                'line_text' => $totals['discount']['code'],
-                'value' => abs($this->convertToCents($totals['discount']['value'])),
-            ];
+            $discountBase = $this->boldQuoteAmounts->getSegmentBaseValue($totals['discount'], $quote);
+
+            if ($discountBase !== null && $discountBase !== 0.0) {
+                $discounts[] = [
+                    'line_text' => (string)$totals['discount']['code'],
+                    'value' => abs($this->convertToCents($discountBase)),
+                ];
+            }
         }
 
         foreach ($totals as $segment) {
-            if (in_array($segment['code'], self::EXPECTED_SEGMENTS) || !$segment['value']) {
+            /** @var Total $segment */
+            if (in_array($segment->getCode(), self::EXPECTED_SEGMENTS, true)) {
                 continue;
             }
 
-            $description = $segment['title'] ?? ucfirst(str_replace('_', ' ', $segment['code']));
+            $baseValue = $this->boldQuoteAmounts->getSegmentBaseValue($segment, $quote);
 
-            if ($segment['value'] > 0) {
+            if ($baseValue === null || $baseValue === 0.0) {
+                continue;
+            }
+
+            $description = $segment['title'] ?? ucfirst(str_replace('_', ' ', (string)$segment->getCode()));
+
+            if ($baseValue > 0) {
                 $fees[] = [
                     'description' => $description,
-                    'value' => $this->convertToCents($segment['value']),
+                    'value' => $this->convertToCents($baseValue),
                 ];
             } else {
                 $discounts[] = [
                     'line_text' => $description,
-                    'value' => abs($this->convertToCents($segment['value'])),
+                    'value' => abs($this->convertToCents($baseValue)),
                 ];
             }
         }

--- a/Model/Order/ResolvePublicOrderId.php
+++ b/Model/Order/ResolvePublicOrderId.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\CheckoutPaymentBooster\Model\Order;
+
+use Bold\CheckoutPaymentBooster\Api\MagentoQuoteBoldOrderRepositoryInterface;
+use Bold\CheckoutPaymentBooster\Model\CheckoutData;
+use Bold\CheckoutPaymentBooster\Model\Log\OrderTracker;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Quote\Model\Quote;
+
+/**
+ * Resolve Bold public order ID for hydrate/auth, reconciling session and quote sources.
+ *
+ * During active checkout the session is authoritative (payments bind to it). Quote extension
+ * and DB are kept in sync; when they drift, the session value is reconciled onto the quote.
+ */
+class ResolvePublicOrderId
+{
+    /**
+     * @var CheckoutData
+     */
+    private $checkoutData;
+
+    /**
+     * @var MagentoQuoteBoldOrderRepositoryInterface
+     */
+    private $magentoQuoteBoldOrderRepository;
+
+    /**
+     * @var SyncPublicOrderIdForQuote
+     */
+    private $syncPublicOrderIdForQuote;
+
+    /**
+     * @var OrderTracker
+     */
+    private $orderTracker;
+
+    /**
+     * @param CheckoutData $checkoutData
+     * @param MagentoQuoteBoldOrderRepositoryInterface $magentoQuoteBoldOrderRepository
+     * @param SyncPublicOrderIdForQuote $syncPublicOrderIdForQuote
+     * @param OrderTracker $orderTracker
+     */
+    public function __construct(
+        CheckoutData $checkoutData,
+        MagentoQuoteBoldOrderRepositoryInterface $magentoQuoteBoldOrderRepository,
+        SyncPublicOrderIdForQuote $syncPublicOrderIdForQuote,
+        OrderTracker $orderTracker
+    ) {
+        $this->checkoutData = $checkoutData;
+        $this->magentoQuoteBoldOrderRepository = $magentoQuoteBoldOrderRepository;
+        $this->syncPublicOrderIdForQuote = $syncPublicOrderIdForQuote;
+        $this->orderTracker = $orderTracker;
+    }
+
+    /**
+     * @param Quote $quote
+     * @return string|null
+     */
+    public function execute(Quote $quote): ?string
+    {
+        $quoteId = (string)$quote->getId();
+        $websiteId = (int)$quote->getStore()->getWebsiteId();
+        $fromSession = $this->normalize($this->checkoutData->getPublicOrderId());
+        $extensionAttributes = $quote->getExtensionAttributes();
+        $fromExtension = $extensionAttributes !== null
+            ? $this->normalize($extensionAttributes->getBoldOrderId())
+            : null;
+        $fromDb = null;
+
+        try {
+            $fromDb = $this->normalize(
+                $this->magentoQuoteBoldOrderRepository->getByQuoteId($quoteId)->getBoldOrderId()
+            );
+        } catch (NoSuchEntityException $e) {
+            // No persisted quote ↔ Bold order relation yet.
+        }
+
+        if ($this->magentoQuoteBoldOrderRepository->isQuoteProcessed($quoteId)) {
+            $this->orderTracker->trace($websiteId, 'resolve_public_order_id_processed_quote', [
+                'quote_id' => $quoteId,
+                'session_public_order_id' => $fromSession,
+                'quote_ext_public_order_id' => $fromExtension,
+                'db_public_order_id' => $fromDb,
+                'resolved_public_order_id' => $fromSession,
+            ]);
+
+            return $fromSession;
+        }
+
+        if ($fromSession !== null && $fromExtension !== null && $fromSession !== $fromExtension) {
+            $this->orderTracker->trace($websiteId, 'resolve_public_order_id_reconcile', [
+                'quote_id' => $quoteId,
+                'session_public_order_id' => $fromSession,
+                'quote_ext_public_order_id' => $fromExtension,
+                'db_public_order_id' => $fromDb,
+            ]);
+            $this->syncPublicOrderIdForQuote->execute($fromSession, $quoteId, $quote);
+
+            return $fromSession;
+        }
+
+        $resolved = $fromSession ?? $fromExtension ?? $fromDb;
+
+        if ($resolved !== null && $fromSession !== null && $resolved === $fromSession) {
+            $this->syncPublicOrderIdForQuote->execute($fromSession, $quoteId, $quote);
+        }
+
+        $this->orderTracker->trace($websiteId, 'resolve_public_order_id', [
+            'quote_id' => $quoteId,
+            'session_public_order_id' => $fromSession,
+            'quote_ext_public_order_id' => $fromExtension,
+            'db_public_order_id' => $fromDb,
+            'resolved_public_order_id' => $resolved,
+            'public_order_ids_match' => $this->idsMatch($fromSession, $fromExtension, $fromDb),
+        ]);
+
+        return $resolved;
+    }
+
+    /**
+     * @param string|null $id
+     * @return string|null
+     */
+    private function normalize(?string $id): ?string
+    {
+        if ($id === null || $id === '') {
+            return null;
+        }
+
+        return $id;
+    }
+
+    /**
+     * @param string|null $fromSession
+     * @param string|null $fromExtension
+     * @param string|null $fromDb
+     * @return bool
+     */
+    private function idsMatch(?string $fromSession, ?string $fromExtension, ?string $fromDb): bool
+    {
+        $ids = array_values(array_filter([$fromSession, $fromExtension, $fromDb], static function ($id) {
+            return $id !== null && $id !== '';
+        }));
+
+        if (count($ids) <= 1) {
+            return true;
+        }
+
+        return count(array_unique($ids)) === 1;
+    }
+}

--- a/Model/Order/SetCompleteState.php
+++ b/Model/Order/SetCompleteState.php
@@ -7,6 +7,7 @@ namespace Bold\CheckoutPaymentBooster\Model\Order;
 use Bold\CheckoutPaymentBooster\Api\MagentoQuoteBoldOrderRepositoryInterface;
 use Bold\CheckoutPaymentBooster\Model\Http\BoldClient;
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Model\Order;
 use Psr\Log\LoggerInterface;
@@ -76,7 +77,15 @@ class SetCompleteState
             $this->logger->error(__('Failed to set complete state for order with id="%1"', $order->getEntityId()));
             return;
         }
-        $quoteId = $order->getQuoteId();
-        $this->magentoQuoteBoldOrderRepository->saveStateAt((string) $quoteId);
+        $quoteId = (string)$order->getQuoteId();
+        $this->magentoQuoteBoldOrderRepository->saveStateAt($quoteId);
+
+        try {
+            $relation = $this->magentoQuoteBoldOrderRepository->getByQuoteId($quoteId);
+            $relation->setBoldOrderId('');
+            $this->magentoQuoteBoldOrderRepository->save($relation);
+        } catch (NoSuchEntityException $e) {
+            // Nothing to clear; relation may not exist for this path.
+        }
     }
 }

--- a/Model/Order/SyncPublicOrderIdForQuote.php
+++ b/Model/Order/SyncPublicOrderIdForQuote.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\CheckoutPaymentBooster\Model\Order;
+
+use Bold\CheckoutPaymentBooster\Api\MagentoQuoteBoldOrderRepositoryInterface;
+use Magento\Quote\Api\Data\CartInterface;
+
+/**
+ * Persist the active Bold public order ID on the Magento quote relation (and extension when available).
+ */
+class SyncPublicOrderIdForQuote
+{
+    /**
+     * @var MagentoQuoteBoldOrderRepositoryInterface
+     */
+    private $magentoQuoteBoldOrderRepository;
+
+    /**
+     * @param MagentoQuoteBoldOrderRepositoryInterface $magentoQuoteBoldOrderRepository
+     */
+    public function __construct(MagentoQuoteBoldOrderRepositoryInterface $magentoQuoteBoldOrderRepository)
+    {
+        $this->magentoQuoteBoldOrderRepository = $magentoQuoteBoldOrderRepository;
+    }
+
+    /**
+     * @param string $publicOrderId
+     * @param string $quoteId
+     * @param CartInterface|null $quote
+     * @return void
+     */
+    public function execute(string $publicOrderId, string $quoteId, ?CartInterface $quote = null): void
+    {
+        $this->magentoQuoteBoldOrderRepository->saveBoldQuotePublicOrderRelation($publicOrderId, $quoteId);
+
+        if ($quote === null) {
+            return;
+        }
+
+        $extensionAttributes = $quote->getExtensionAttributes();
+        if ($extensionAttributes !== null) {
+            $extensionAttributes->setBoldOrderId($publicOrderId);
+        }
+    }
+}

--- a/Model/Payment/Authorize.php
+++ b/Model/Payment/Authorize.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bold\CheckoutPaymentBooster\Model\Payment;
 
 use Bold\CheckoutPaymentBooster\Model\Http\BoldClient;
+use Bold\CheckoutPaymentBooster\Model\Log\OrderTracker;
 use Magento\Framework\Exception\LocalizedException;
 
 /**
@@ -20,12 +21,20 @@ class Authorize
     private $client;
 
     /**
+     * @var OrderTracker
+     */
+    private $orderTracker;
+
+    /**
      * @param BoldClient $client
+     * @param OrderTracker $orderTracker
      */
     public function __construct(
-        BoldClient $client
+        BoldClient $client,
+        OrderTracker $orderTracker
     ) {
         $this->client = $client;
+        $this->orderTracker = $orderTracker;
     }
 
     /**
@@ -33,6 +42,7 @@ class Authorize
      *
      * @param string $publicOrderId
      * @param int $websiteId
+     * @param int|null $quoteId
      * @return array{
      *     data: array{
      *         transactions: array{
@@ -46,17 +56,37 @@ class Authorize
      * }
      * @throws LocalizedException
      */
-    public function execute(string $publicOrderId, int $websiteId): array
+    public function execute(string $publicOrderId, int $websiteId, ?int $quoteId = null): array
     {
         $url = sprintf(self::PATH_PAYMENTS_AUTH, $publicOrderId);
+        $this->orderTracker->trace($websiteId, 'auth_full_start', [
+            'public_order_id' => $publicOrderId,
+            'website_id' => $websiteId,
+            'quote_id' => $quoteId,
+            'url' => $url,
+        ]);
         $result = $this->client->post($websiteId, $url, []);
         if ($result->getErrors()) {
+            $this->orderTracker->trace($websiteId, 'auth_full_failed', [
+                'public_order_id' => $publicOrderId,
+                'website_id' => $websiteId,
+                'quote_id' => $quoteId,
+                'errors' => $result->getErrors(),
+            ]);
             $message = isset(current($result->getErrors())['message'])
                 ? __(current($result->getErrors())['message'])
                 : __('The payment cannot be authorized.');
             throw new LocalizedException($message);
         }
 
-        return $result->getBody();
+        $body = $result->getBody();
+        $this->orderTracker->trace($websiteId, 'auth_full_success', [
+            'public_order_id' => $publicOrderId,
+            'website_id' => $websiteId,
+            'quote_id' => $quoteId,
+            'transaction_id' => $body['data']['transactions'][0]['transaction_id'] ?? null,
+        ]);
+
+        return $body;
     }
 }

--- a/Model/Payment/Gateway/Command/CapturePayment.php
+++ b/Model/Payment/Gateway/Command/CapturePayment.php
@@ -63,7 +63,7 @@ class CapturePayment implements CommandInterface
         $orderExtensionData->setIsCaptureInProgress(true);
         $this->orderExtensionDataRepository->save($orderExtensionData);
         try {
-            if ((float)$order->getGrandTotal() === $amount) {
+            if ((float)$order->getBaseGrandTotal() === $amount) {
                 $payment->setTransactionId($this->gatewayService->captureFull($order))
                     ->setShouldCloseParentTransaction(true);
                 return;

--- a/Model/Payment/Gateway/Command/RefundPayment.php
+++ b/Model/Payment/Gateway/Command/RefundPayment.php
@@ -64,7 +64,7 @@ class RefundPayment implements CommandInterface
         $orderExtensionData->setIsRefundInProgress(true);
         $this->orderExtensionDataRepository->save($orderExtensionData);
         try {
-            if ((float)$order->getGrandTotal() <= $amount) {
+            if ((float)$order->getBaseGrandTotal() <= $amount) {
                 $transactionId = $this->gatewayService->refundFull($order);
                 $payment->setTransactionId($transactionId)
                     ->setIsTransactionClosed(true)

--- a/Model/Quote/BoldQuoteAmounts.php
+++ b/Model/Quote/BoldQuoteAmounts.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\CheckoutPaymentBooster\Model\Quote;
+
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\Quote\Address;
+use Magento\Quote\Model\Quote\Address\Rate;
+use Magento\Quote\Model\Quote\Address\Total;
+use Magento\Quote\Model\Quote\Item;
+
+/**
+ * Extracts base-currency amounts from Magento quotes for Bold API payloads.
+ */
+class BoldQuoteAmounts
+{
+    /**
+     * Bold payments always use the store base currency.
+     */
+    public function getCurrencyCode(Quote $quote): string
+    {
+        $code = $quote->getBaseCurrencyCode();
+
+        if ($code !== null && $code !== '') {
+            return $code;
+        }
+
+        return (string)$quote->getStore()->getBaseCurrencyCode();
+    }
+
+    public function getGrandTotal(Quote $quote): float
+    {
+        return (float)$quote->getBaseGrandTotal();
+    }
+
+    public function getSubtotal(Quote $quote): float
+    {
+        return (float)$quote->getBaseSubtotal();
+    }
+
+    public function getTaxAmount(Quote $quote): float
+    {
+        if ($quote->getIsVirtual()) {
+            $total = 0.0;
+
+            foreach ($quote->getItems() ?? [] as $item) {
+                if (!$item instanceof Item) {
+                    continue;
+                }
+
+                $total += (float)($item->getBaseTaxAmount() ?? 0.00);
+            }
+
+            return $total;
+        }
+
+        return (float)($quote->getShippingAddress()->getBaseTaxAmount() ?? 0.00);
+    }
+
+    public function getShippingAmount(Quote $quote): float
+    {
+        if ($quote->getIsVirtual()) {
+            return 0.0;
+        }
+
+        return (float)($quote->getShippingAddress()->getBaseShippingAmount() ?? 0.00);
+    }
+
+    public function getDiscountAmount(Quote $quote): float
+    {
+        $address = $quote->getIsVirtual()
+            ? $quote->getBillingAddress()
+            : $quote->getShippingAddress();
+
+        return abs((float)($address->getBaseDiscountAmount() ?? 0.0));
+    }
+
+    public function getItemRowAmount(Item $item, bool $taxIncluded): float
+    {
+        if ($taxIncluded) {
+            return (float)$item->getBaseRowTotalInclTax() - (float)($item->getBaseTaxAmount() ?? 0);
+        }
+
+        return (float)$item->getBaseRowTotal();
+    }
+
+    public function getItemUnitPrice(Item $item, bool $taxIncluded): float
+    {
+        $qty = (float)$item->getQty();
+
+        if ($qty <= 0) {
+            return 0.0;
+        }
+
+        return $this->getItemRowAmount($item, $taxIncluded) / $qty;
+    }
+
+    public function getShippingRateAmount(Rate $rate, Address $shippingAddress): float
+    {
+        if ($rate->getCode() === $shippingAddress->getShippingMethod()) {
+            return (float)$shippingAddress->getBaseShippingAmount();
+        }
+
+        $baseToQuoteRate = (float)$shippingAddress->getQuote()->getBaseToQuoteRate();
+        $price = (float)$rate->getPrice();
+
+        if ($baseToQuoteRate > 0) {
+            return $price / $baseToQuoteRate;
+        }
+
+        return $price;
+    }
+
+    /**
+     * Base amount for extension/custom total segments. Returns null when only display currency is present.
+     */
+    public function getCustomTotalBaseAmount(Total $total): ?float
+    {
+        $code = (string)$total->getCode();
+        $baseAmount = (float)$total->getBaseTotalAmount($code);
+        $displayValue = (float)($total->getData('value') ?? 0);
+
+        if ($baseAmount === 0.0 && $displayValue !== 0.0) {
+            return null;
+        }
+
+        return $baseAmount;
+    }
+
+    /**
+     * Base value for a fee/discount total segment used during order hydration.
+     */
+    public function getSegmentBaseValue(Total $segment, Quote $quote): ?float
+    {
+        $code = (string)$segment->getCode();
+        $baseAmount = (float)$segment->getBaseTotalAmount($code);
+        $displayValue = (float)($segment->getData('value') ?? 0);
+
+        if ($baseAmount === 0.0 && $displayValue !== 0.0) {
+            return null;
+        }
+
+        if ($baseAmount !== 0.0) {
+            return $baseAmount;
+        }
+
+        if ($code === 'discount') {
+            return $this->getDiscountAmount($quote);
+        }
+
+        return 0.0;
+    }
+}

--- a/Model/Quote/GetCartLineItems.php
+++ b/Model/Quote/GetCartLineItems.php
@@ -151,7 +151,7 @@ class GetCartLineItems
     private function getLineItemPrice(CartItemInterface $item): int
     {
         $item = $item->getParentItem() ?: $item;
-        return $this->convertToCents((float)$item->getPrice());
+        return $this->convertToCents((float)$item->getBasePrice());
     }
 
     /**
@@ -217,7 +217,7 @@ class GetCartLineItems
     private function getLineItemDiscount(Item $item): int
     {
         $item = $item->getParentItem() ?: $item;
-        $discountAmount = $item->getOriginalPrice() - $item->getPrice();
+        $discountAmount = $item->getBaseOriginalPrice() - $item->getBasePrice();
 
         return $this->convertToCents((float)$discountAmount);
     }

--- a/Observer/Order/BeforePlaceObserver.php
+++ b/Observer/Order/BeforePlaceObserver.php
@@ -4,21 +4,16 @@ declare(strict_types=1);
 
 namespace Bold\CheckoutPaymentBooster\Observer\Order;
 
-use Bold\CheckoutPaymentBooster\Api\Data\MagentoQuoteBoldOrderInterface;
 use Bold\CheckoutPaymentBooster\Api\MagentoQuoteBoldOrderRepositoryInterface;
-use Bold\CheckoutPaymentBooster\Api\MagentoQuoteBoldOrderRepositoryInterfaceFactory;
-use Bold\CheckoutPaymentBooster\Model\CheckoutData;
-use Bold\CheckoutPaymentBooster\Model\MagentoQuoteBoldOrder;
 use Bold\CheckoutPaymentBooster\Model\Order\CheckPaymentMethod;
 use Bold\CheckoutPaymentBooster\Model\Order\HydrateOrderFromQuote;
+use Bold\CheckoutPaymentBooster\Model\Order\ResolvePublicOrderId;
 use Bold\CheckoutPaymentBooster\Model\Payment\Authorize;
-use Exception;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Serialize\SerializerInterface;
-use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
 use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Quote\Api\Data\CartInterface;
 use Magento\Quote\Model\Quote;
@@ -26,7 +21,6 @@ use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\Data\OrderPaymentInterface;
 use Magento\Sales\Api\Data\TransactionInterface;
 use Magento\Sales\Model\Order\Payment;
-use Psr\Log\LoggerInterface;
 
 /**
  * Authorize Bold payments before placing order.
@@ -42,11 +36,6 @@ class BeforePlaceObserver implements ObserverInterface
      * @var CartRepositoryInterface
      */
     private $cartRepository;
-
-    /**
-     * @var CheckoutData
-     */
-    private $checkoutData;
 
     /**
      * @var HydrateOrderFromQuote
@@ -66,31 +55,34 @@ class BeforePlaceObserver implements ObserverInterface
     /** @var MagentoQuoteBoldOrderRepositoryInterface */
     private $magentoQuoteBoldOrderRepository;
 
+    /** @var ResolvePublicOrderId */
+    private $resolvePublicOrderId;
+
     /**
      * @param Authorize $authorize
      * @param CartRepositoryInterface $cartRepository
-     * @param CheckoutData $checkoutData
      * @param HydrateOrderFromQuote $hydrateOrderFromQuote
      * @param CheckPaymentMethod $checkPaymentMethod
      * @param SerializerInterface $serializer
      * @param MagentoQuoteBoldOrderRepositoryInterface $magentoQuoteBoldOrderRepository
+     * @param ResolvePublicOrderId $resolvePublicOrderId
      */
     public function __construct(
         Authorize $authorize,
         CartRepositoryInterface $cartRepository,
-        CheckoutData $checkoutData,
         HydrateOrderFromQuote $hydrateOrderFromQuote,
         CheckPaymentMethod $checkPaymentMethod,
         SerializerInterface $serializer,
-        MagentoQuoteBoldOrderRepositoryInterface $magentoQuoteBoldOrderRepository
+        MagentoQuoteBoldOrderRepositoryInterface $magentoQuoteBoldOrderRepository,
+        ResolvePublicOrderId $resolvePublicOrderId
     ) {
         $this->authorize = $authorize;
         $this->cartRepository = $cartRepository;
-        $this->checkoutData = $checkoutData;
         $this->hydrateOrderFromQuote = $hydrateOrderFromQuote;
         $this->checkPaymentMethod = $checkPaymentMethod;
         $this->serializer = $serializer;
         $this->magentoQuoteBoldOrderRepository = $magentoQuoteBoldOrderRepository;
+        $this->resolvePublicOrderId = $resolvePublicOrderId;
     }
 
     /**
@@ -110,15 +102,11 @@ class BeforePlaceObserver implements ObserverInterface
         $quoteId = $order->getQuoteId();
         /** @var CartInterface&Quote $quote */
         $quote = $this->cartRepository->get($quoteId);
-        $publicOrderId = $quote->getExtensionAttributes()->getBoldOrderId() ?? $this->checkoutData->getPublicOrderId();
-
-        if ($publicOrderId && $quoteId) {
-            $this->magentoQuoteBoldOrderRepository->saveBoldQuotePublicOrderRelation($publicOrderId, (string) $quoteId);
-        }
+        $publicOrderId = $this->resolvePublicOrderId->execute($quote);
 
         $websiteId = (int)$quote->getStore()->getWebsiteId();
         $this->hydrateOrderFromQuote->hydrate($quote, $publicOrderId);
-        $transactionData = $this->authorize->execute($publicOrderId, $websiteId);
+        $transactionData = $this->authorize->execute($publicOrderId, $websiteId, (int) $quoteId);
         $this->saveTransactionData($order, $transactionData);
         $this->magentoQuoteBoldOrderRepository->saveAuthorizedAt((string) $quoteId);
     }

--- a/Plugin/Checkout/Model/SessionPlugin.php
+++ b/Plugin/Checkout/Model/SessionPlugin.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Bold\CheckoutPaymentBooster\Plugin\Checkout\Model;
 
+use Bold\CheckoutPaymentBooster\Model\CheckoutData;
 use Closure;
 use Magento\Checkout\Model\Session;
 use Magento\Framework\Exception\NoSuchEntityException;
@@ -18,9 +19,17 @@ class SessionPlugin
      */
     private $quoteRepository;
 
-    public function __construct(CartRepositoryInterface $quoteRepository)
-    {
+    /**
+     * @var CheckoutData
+     */
+    private $checkoutData;
+
+    public function __construct(
+        CartRepositoryInterface $quoteRepository,
+        CheckoutData $checkoutData
+    ) {
         $this->quoteRepository = $quoteRepository;
+        $this->checkoutData = $checkoutData;
     }
 
     public function aroundClearQuote(Session $subject, Closure $proceed): Session
@@ -41,6 +50,8 @@ class SessionPlugin
         if (!$lastQuote->getData('is_digital_wallets')) {
             return $proceed();
         }
+
+        $this->checkoutData->resetCheckoutData();
 
         return $subject;
     }

--- a/Plugin/Quote/Api/CartRepositoryInterfacePlugin.php
+++ b/Plugin/Quote/Api/CartRepositoryInterfacePlugin.php
@@ -7,7 +7,9 @@ namespace Bold\CheckoutPaymentBooster\Plugin\Quote\Api;
 use Bold\CheckoutPaymentBooster\Api\Data\MagentoQuoteBoldOrderInterface;
 use Bold\CheckoutPaymentBooster\Api\Data\MagentoQuoteBoldOrderInterfaceFactory;
 use Bold\CheckoutPaymentBooster\Api\MagentoQuoteBoldOrderRepositoryInterface;
+use Bold\CheckoutPaymentBooster\Model\CheckoutData;
 use Bold\CheckoutPaymentBooster\Model\MagentoQuoteBoldOrder;
+use Bold\CheckoutPaymentBooster\Model\Order\SyncPublicOrderIdForQuote;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Quote\Api\CartRepositoryInterface;
@@ -24,12 +26,26 @@ class CartRepositoryInterfacePlugin
      */
     private $magentoQuoteBoldOrderInterfaceFactory;
 
+    /**
+     * @var CheckoutData
+     */
+    private $checkoutData;
+
+    /**
+     * @var SyncPublicOrderIdForQuote
+     */
+    private $syncPublicOrderIdForQuote;
+
     public function __construct(
         MagentoQuoteBoldOrderRepositoryInterface $magentoQuoteBoldOrderRepository,
-        MagentoQuoteBoldOrderInterfaceFactory $magentoQuoteBoldOrderInterfaceFactory
+        MagentoQuoteBoldOrderInterfaceFactory $magentoQuoteBoldOrderInterfaceFactory,
+        CheckoutData $checkoutData,
+        SyncPublicOrderIdForQuote $syncPublicOrderIdForQuote
     ) {
         $this->magentoQuoteBoldOrderRepository = $magentoQuoteBoldOrderRepository;
         $this->magentoQuoteBoldOrderInterfaceFactory = $magentoQuoteBoldOrderInterfaceFactory;
+        $this->checkoutData = $checkoutData;
+        $this->syncPublicOrderIdForQuote = $syncPublicOrderIdForQuote;
     }
 
     /**
@@ -42,7 +58,26 @@ class CartRepositoryInterfacePlugin
     {
         $cartExtension = $result->getExtensionAttributes();
 
-        if ($cartExtension === null || $cartExtension->getBoldOrderId() !== null) {
+        if ($cartExtension === null) {
+            return $result;
+        }
+
+        $quoteId = (string)$cartId;
+        $sessionPublicOrderId = $this->normalizePublicOrderId($this->checkoutData->getPublicOrderId());
+
+        if (
+            $sessionPublicOrderId !== null
+            && !$this->magentoQuoteBoldOrderRepository->isQuoteProcessed($quoteId)
+        ) {
+            $extensionPublicOrderId = $this->normalizePublicOrderId($cartExtension->getBoldOrderId());
+            if ($extensionPublicOrderId !== $sessionPublicOrderId) {
+                $this->syncPublicOrderIdForQuote->execute($sessionPublicOrderId, $quoteId, $result);
+
+                return $result;
+            }
+        }
+
+        if ($cartExtension->getBoldOrderId() !== null) {
             return $result;
         }
 
@@ -86,5 +121,18 @@ class CartRepositoryInterfacePlugin
             $this->magentoQuoteBoldOrderRepository->save($magentoQuoteBoldOrder);
         } catch (LocalizedException $localizedException) {// phpcs:ignore Magento2.CodeAnalysis.EmptyBlock.DetectedCatch
         }
+    }
+
+    /**
+     * @param string|null $publicOrderId
+     * @return string|null
+     */
+    private function normalizePublicOrderId(?string $publicOrderId): ?string
+    {
+        if ($publicOrderId === null || $publicOrderId === '') {
+            return null;
+        }
+
+        return $publicOrderId;
     }
 }

--- a/Plugin/Quote/Api/CartRepositoryInterfacePlugin.php
+++ b/Plugin/Quote/Api/CartRepositoryInterfacePlugin.php
@@ -52,11 +52,12 @@ class CartRepositoryInterfacePlugin
             return $result;
         }
 
-        if ($magentoQuoteBoldOrder->getBoldOrderId() === null) {
+        $boldOrderId = $magentoQuoteBoldOrder->getBoldOrderId();
+        if ($boldOrderId === null || $boldOrderId === '') {
             return $result;
         }
 
-        $cartExtension->setBoldOrderId($magentoQuoteBoldOrder->getBoldOrderId());
+        $cartExtension->setBoldOrderId($boldOrderId);
 
         return $result;
     }

--- a/Service/ExpressPay/Order/Create.php
+++ b/Service/ExpressPay/Order/Create.php
@@ -7,6 +7,8 @@ namespace Bold\CheckoutPaymentBooster\Service\ExpressPay\Order;
 use Bold\CheckoutPaymentBooster\Api\ExpressPay\Order\CreateInterface;
 use Bold\CheckoutPaymentBooster\Api\Http\ClientInterface;
 use Bold\CheckoutPaymentBooster\Model\Config;
+use Bold\CheckoutPaymentBooster\Model\Log\OrderTracker;
+use Bold\CheckoutPaymentBooster\Model\Order\SyncPublicOrderIdForQuote;
 use Bold\CheckoutPaymentBooster\Service\ExpressPay\QuoteConverter;
 use Exception;
 use Magento\Checkout\Model\Session;
@@ -57,13 +59,25 @@ class Create implements CreateInterface
      */
     private $config;
 
+    /**
+     * @var OrderTracker
+     */
+    private $orderTracker;
+
+    /**
+     * @var SyncPublicOrderIdForQuote
+     */
+    private $syncPublicOrderIdForQuote;
+
     public function __construct(
         MaskedQuoteIdToQuoteIdInterface $maskedQuoteIdToQuoteId,
         CartRepositoryInterface $cartRepository,
         QuoteConverter $quoteConverter,
         ClientInterface $httpClient,
         SessionManagerInterface $checkoutSession,
-        Config $config
+        Config $config,
+        OrderTracker $orderTracker,
+        SyncPublicOrderIdForQuote $syncPublicOrderIdForQuote
     ) {
         $this->maskedQuoteIdToQuoteId = $maskedQuoteIdToQuoteId;
         $this->cartRepository = $cartRepository;
@@ -71,6 +85,8 @@ class Create implements CreateInterface
         $this->httpClient = $httpClient;
         $this->checkoutSession = $checkoutSession;
         $this->config = $config;
+        $this->orderTracker = $orderTracker;
+        $this->syncPublicOrderIdForQuote = $syncPublicOrderIdForQuote;
     }
 
     public function execute($quoteMaskId, $publicOrderId, $gatewayId, $shippingStrategy, $shouldVault, $paymentSource): array
@@ -133,6 +149,26 @@ class Create implements CreateInterface
         $websiteId = (int)$quote->getStore()->getWebsiteId();
         $uri = 'checkout/orders/{{shopId}}/wallet_pay';
 
+        $publicOrderIdFromQuote = null;
+        $extensionAttributes = $quote->getExtensionAttributes();
+        if ($extensionAttributes !== null) {
+            $publicOrderIdFromQuote = $extensionAttributes->getBoldOrderId();
+        }
+        /** @var Session $session */
+        $session = $this->checkoutSession;
+        $sessionCheckoutData = $session->getBoldCheckoutData();
+        $publicOrderIdFromSession = $sessionCheckoutData['data']['public_order_id'] ?? null;
+
+        $this->orderTracker->trace($websiteId, 'express_pay_create', [
+            'quote_id' => $quote->getId(),
+            'customer_id' => $quote->getCustomerId(),
+            'request_public_order_id' => $publicOrderId,
+            'quote_ext_public_order_id' => $publicOrderIdFromQuote,
+            'session_public_order_id' => $publicOrderIdFromSession,
+            'gateway_id' => $gatewayId,
+            'grand_total' => $quote->getGrandTotal(),
+        ]);
+
         $expressPayData = $this->quoteConverter->convertFullQuote($quote, $gatewayId);
         $expressPayData['shipping_strategy'] = $shippingStrategy;
         $expressPayData['public_order_id'] = $publicOrderId;
@@ -174,6 +210,14 @@ class Create implements CreateInterface
         if ($result->getStatus() !== 200 || count($resultData) === 0) {
             throw new LocalizedException(__('An unknown error occurred while creating the Express Pay order.'));
         }
+
+        $this->syncPublicOrderIdForQuote->execute($publicOrderId, (string) $quote->getId(), $quote);
+
+        $this->orderTracker->trace($websiteId, 'express_pay_create_success', [
+            'quote_id' => $quote->getId(),
+            'public_order_id' => $publicOrderId,
+            'bold_order_id' => $resultData['data']['order_id'] ?? null,
+        ]);
 
         return [
             'order_id' => $resultData['data']['order_id']

--- a/Service/ExpressPay/QuoteConverter.php
+++ b/Service/ExpressPay/QuoteConverter.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Bold\CheckoutPaymentBooster\Service\ExpressPay;
 
 use Bold\CheckoutPaymentBooster\Model\Config;
+use Bold\CheckoutPaymentBooster\Model\Quote\BoldQuoteAmounts;
 use Magento\Customer\Api\Data\CustomerInterface;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Quote\Api\Data\CartInterface;
-use Magento\Quote\Api\Data\CartItemInterface;
 use Magento\Quote\Model\Quote;
 use Magento\Quote\Model\Quote\Address\Rate;
 use Magento\Quote\Model\Quote\Address\Total;
@@ -46,14 +46,23 @@ class QuoteConverter
     private $config;
 
     /**
+     * @var BoldQuoteAmounts
+     */
+    private $boldQuoteAmounts;
+
+    /**
      * @var bool
      */
     private $areTotalsCollected = false;
 
-    public function __construct(ScopeConfigInterface $scopeConfig, Config $config)
-    {
+    public function __construct(
+        ScopeConfigInterface $scopeConfig,
+        Config $config,
+        BoldQuoteAmounts $boldQuoteAmounts
+    ) {
         $this->scopeConfig = $scopeConfig;
         $this->config = $config;
+        $this->boldQuoteAmounts = $boldQuoteAmounts;
     }
 
     /**
@@ -172,7 +181,7 @@ class QuoteConverter
                 'shipping_options' => [],
             ],
         ];
-        $currencyCode = $quote->getCurrency() !== null ? $quote->getCurrency()->getQuoteCurrencyCode() : '';
+        $currencyCode = $this->boldQuoteAmounts->getCurrencyCode($quote);
         $usedRateCodes = [];
         /** @var Rate[] $shippingRates */
         $shippingRates = array_values(array_filter(
@@ -190,10 +199,10 @@ class QuoteConverter
         $hasRequiredAddressData = ($shippingAddress->getCity() && $shippingAddress->getCountryId());
 
         if ($hasRequiredAddressData && count($shippingRates) > 0) {
+            $boldQuoteAmounts = $this->boldQuoteAmounts;
             $convertedQuote['order_data']['shipping_options'] = array_map(
-                static function (Rate $rate) use ($currencyCode, $shippingAddress): array {
-                    $price = ($rate->getCode() === $shippingAddress->getShippingMethod())
-                        ? $shippingAddress->getShippingAmount() : $rate->getPrice();
+                static function (Rate $rate) use ($currencyCode, $shippingAddress, $boldQuoteAmounts): array {
+                    $price = $boldQuoteAmounts->getShippingRateAmount($rate, $shippingAddress);
                     return [
                         'id' => $rate->getCode(),
                         'label' => trim("{$rate->getCarrierTitle()} - {$rate->getMethodTitle()}", ' -'),
@@ -236,7 +245,7 @@ class QuoteConverter
                 'type' => 'SHIPPING',
                 'amount' => [
                     'currency_code' => $currencyCode ?? '',
-                    'value' => number_format((float)$shippingAddress->getShippingAmount(), 2, '.', ''),
+                    'value' => number_format($this->boldQuoteAmounts->getShippingAmount($quote), 2, '.', ''),
                 ],
             ];
         }
@@ -257,25 +266,25 @@ class QuoteConverter
             return [];
         }
 
-        $currencyCode = $quote->getCurrency() !== null ? $quote->getCurrency()->getQuoteCurrencyCode() : '';
+        /** @var Item[] $quoteItems */
+        $currencyCode = $this->boldQuoteAmounts->getCurrencyCode($quote);
         $websiteId = (int)$quote->getStore()->getWebsiteId();
         $taxIncluded = $this->config->isTaxIncludedInPrices($websiteId);
+        $boldQuoteAmounts = $this->boldQuoteAmounts;
 
         $convertedQuote = [
             'order_data' => [
                 'items' => array_map(
-                    static function (CartItemInterface $cartItem) use ($currencyCode, $taxIncluded): array {
-                        $itemPrice = $taxIncluded
-                            ? $cartItem->getRowTotalInclTax() - $cartItem->getTaxAmount()
-                            : $cartItem->getRowTotal();
+                    static function (Item $cartItem) use ($currencyCode, $taxIncluded, $boldQuoteAmounts): array {
+                        $unitPrice = $boldQuoteAmounts->getItemUnitPrice($cartItem, $taxIncluded);
 
                         return [
                             'name' => $cartItem->getName() ?? '',
                             'sku' => $cartItem->getSku() ?? '',
                             'unit_amount' => [
                                 'currency_code' => $currencyCode ?? '',
-                                'value' =>  number_format(
-                                    $itemPrice / $cartItem->getQty(),
+                                'value' => number_format(
+                                    $unitPrice,
                                     2,
                                     '.',
                                     ''
@@ -300,18 +309,16 @@ class QuoteConverter
                     'value' => number_format(
                         array_sum(
                             array_map(
-                                static function (CartItemInterface $cartItem) use ($taxIncluded) {
-                                    $itemPrice = $taxIncluded
-                                        ? $cartItem->getRowTotalInclTax() - $cartItem->getTaxAmount()
-                                        : $cartItem->getRowTotal();
+                                static function (Item $cartItem) use ($taxIncluded, $boldQuoteAmounts) {
+                                    $rowAmount = $boldQuoteAmounts->getItemRowAmount($cartItem, $taxIncluded);
                                     $roundedItemPrice = number_format(
-                                        $itemPrice / $cartItem->getQty(),
+                                        $rowAmount / $cartItem->getQty(),
                                         2,
                                         '.',
                                         ''
                                     );
 
-                                    return $roundedItemPrice * $cartItem->getQty();
+                                    return (float)$roundedItemPrice * $cartItem->getQty();
                                 },
                                 $quoteItems
                             )
@@ -334,7 +341,7 @@ class QuoteConverter
      */
     public function convertTotal(Quote $quote): array
     {
-        $currencyCode = $quote->getCurrency() !== null ? $quote->getCurrency()->getQuoteCurrencyCode() : '';
+        $currencyCode = $this->boldQuoteAmounts->getCurrencyCode($quote);
 
         if (!$this->areTotalsCollected) {
             $quote->collectTotals(); // Ensure that we have the correct grand total for the quote
@@ -345,8 +352,8 @@ class QuoteConverter
         return [
             'order_data' => [
                 'amount' => [
-                    'currency_code' => $currencyCode ?? '',
-                    'value' => number_format((float)$quote->getGrandTotal(), 2, '.', ''),
+                    'currency_code' => $currencyCode,
+                    'value' => number_format($this->boldQuoteAmounts->getGrandTotal($quote), 2, '.', ''),
                 ],
             ],
         ];
@@ -357,40 +364,15 @@ class QuoteConverter
      */
     public function convertTaxes(Quote $quote): array
     {
-        $currencyCode = $quote->getCurrency() !== null ? $quote->getCurrency()->getQuoteCurrencyCode() : '';
+        $currencyCode = $this->boldQuoteAmounts->getCurrencyCode($quote);
         $convertedQuote = [
             'order_data' => [
                 'tax_total' => [
-                    'currency_code' => $currencyCode ?? '',
-                    'value' => '',
+                    'currency_code' => $currencyCode,
+                    'value' => number_format($this->boldQuoteAmounts->getTaxAmount($quote), 2, '.', ''),
                 ],
             ],
         ];
-
-        if ($quote->getIsVirtual()) {
-            /** @var Item[] $items */
-            $items = $quote->getItems();
-            $convertedQuote['order_data']['tax_total']['value'] = number_format(
-                array_sum(
-                    array_map(
-                        static function (Item $item): float {
-                            return $item->getTaxAmount() ?? 0.00;
-                        },
-                        $items
-                    )
-                ),
-                2,
-                '.',
-                ''
-            );
-        } else {
-            $convertedQuote['order_data']['tax_total']['value'] = number_format(
-                (float)($quote->getShippingAddress()->getTaxAmount() ?? 0.00),
-                2,
-                '.',
-                ''
-            );
-        }
 
         return $convertedQuote;
     }
@@ -400,18 +382,13 @@ class QuoteConverter
      */
     public function convertDiscount(Quote $quote): array
     {
-        $currencyCode = $quote->getCurrency() !== null ? $quote->getCurrency()->getQuoteCurrencyCode() : '';
+        $currencyCode = $this->boldQuoteAmounts->getCurrencyCode($quote);
 
         return [
             'order_data' => [
                 'discount' => [
-                    'currency_code' => $currencyCode ?? '',
-                    'value' => number_format(
-                        (float)($quote->getSubtotal() - $quote->getSubtotalWithDiscount()),
-                        2,
-                        '.',
-                        ''
-                    ),
+                    'currency_code' => $currencyCode,
+                    'value' => number_format($this->boldQuoteAmounts->getDiscountAmount($quote), 2, '.', ''),
                 ],
             ],
         ];
@@ -430,7 +407,7 @@ class QuoteConverter
             $this->areTotalsCollected = true;
         }
 
-        $currencyCode = $quote->getCurrency() !== null ? $quote->getCurrency()->getQuoteCurrencyCode() : '';
+        $currencyCode = $this->boldQuoteAmounts->getCurrencyCode($quote);
         $excludedTotals = ['subtotal', 'shipping', 'tax', 'grand_total'];
         $customTotals = array_filter(
             $quote->getTotals(),
@@ -443,27 +420,28 @@ class QuoteConverter
             return;
         }
 
+        $boldQuoteAmounts = $this->boldQuoteAmounts;
         $customTotalsValue = 0;
         $totalItems = array_filter(
             array_map(
-                static function (Total $total) use ($currencyCode, &$customTotalsValue): ?array {
-                    /** @var string|null $name */
-                    $name = $total->getData('title') ?? '';
-                    /** @var float|string|null $value */
-                    $value = $total->getData('value') ?? 0;
+                static function (Total $total) use ($currencyCode, $boldQuoteAmounts, &$customTotalsValue): ?array {
+                    $baseValue = $boldQuoteAmounts->getCustomTotalBaseAmount($total);
 
-                    if ((float)$value === 0.00) {
+                    if ($baseValue === null || $baseValue === 0.0) {
                         return null;
                     }
 
-                    $customTotalsValue += (float)$value;
+                    /** @var string|null $name */
+                    $name = $total->getData('title') ?? '';
+
+                    $customTotalsValue += $baseValue;
 
                     return [
                         'name' => $name,
                         'sku' => $total->getCode() ?? '',
                         'unit_amount' => [
-                            'currency_code' => $currencyCode ?? '',
-                            'value' => number_format((float)$value, 2, '.', ''),
+                            'currency_code' => $currencyCode,
+                            'value' => number_format($baseValue, 2, '.', ''),
                         ],
                         'quantity' => 1,
                         'is_shipping_required' => false,

--- a/Test/Integration/Controller/Digitalwallets/Checkout/GetPaymentGatewaysTest.php
+++ b/Test/Integration/Controller/Digitalwallets/Checkout/GetPaymentGatewaysTest.php
@@ -16,6 +16,10 @@ use Magento\TestFramework\TestCase\AbstractController;
 
 /**
  * @magentoAppIsolation enabled
+ * @magentoConfigFixture current_store currency/options/base USD
+ * @magentoConfigFixture current_store currency/options/default USD
+ * @magentoConfigFixture current_store currency/options/allow USD,EUR
+ * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/multi_currency_store.php
  */
 class GetPaymentGatewaysTest extends AbstractController
 {

--- a/Test/Integration/Controller/Digitalwallets/Quote/CreateTest.php
+++ b/Test/Integration/Controller/Digitalwallets/Quote/CreateTest.php
@@ -25,6 +25,12 @@ use Magento\TestFramework\TestCase\AbstractController;
 
 use function __;
 
+/**
+ * @magentoConfigFixture current_store currency/options/base USD
+ * @magentoConfigFixture current_store currency/options/default USD
+ * @magentoConfigFixture current_store currency/options/allow USD,EUR
+ * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/multi_currency_store.php
+ */
 class CreateTest extends AbstractController
 {
     public function testCreatesQuoteSuccessfully(): void

--- a/Test/Integration/Controller/Digitalwallets/Quote/DeactivateTest.php
+++ b/Test/Integration/Controller/Digitalwallets/Quote/DeactivateTest.php
@@ -18,6 +18,12 @@ use Magento\TestFramework\TestCase\AbstractController;
 
 use function is_string;
 
+/**
+ * @magentoConfigFixture current_store currency/options/base USD
+ * @magentoConfigFixture current_store currency/options/default USD
+ * @magentoConfigFixture current_store currency/options/allow USD,EUR
+ * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/multi_currency_store.php
+ */
 class DeactivateTest extends AbstractController
 {
     /**

--- a/Test/Integration/Cron/DigitalWallets/DeactivateQuotesTest.php
+++ b/Test/Integration/Cron/DigitalWallets/DeactivateQuotesTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Bold\CheckoutPaymentBooster\Test\Integration\Cron\DigitalWallets;
 
+use Bold\CheckoutPaymentBooster\Test\Integration\_Support\IntegrationTestCase;
 use Bold\CheckoutPaymentBooster\Cron\DigitalWallets\DeactivateQuotes;
 use Magento\Cron\Model\ConfigInterface;
 use Magento\TestFramework\Helper\Bootstrap;
-use PHPUnit\Framework\TestCase;
 
-class DeactivateQuotesTest extends TestCase
+class DeactivateQuotesTest extends IntegrationTestCase
 {
     public function testIsConfiguredProperly(): void
     {

--- a/Test/Integration/Model/CheckoutDataTest.php
+++ b/Test/Integration/Model/CheckoutDataTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\CheckoutPaymentBooster\Test\Integration\Model;
+
+use Bold\CheckoutPaymentBooster\Api\MagentoQuoteBoldOrderRepositoryInterface;
+use Bold\CheckoutPaymentBooster\Model\CheckoutData;
+use Bold\CheckoutPaymentBooster\Model\Eps\GetFastlaneStyles;
+use Bold\CheckoutPaymentBooster\Model\InitOrderFromQuote;
+use Bold\CheckoutPaymentBooster\Model\ResumeOrder;
+use Magento\Checkout\Model\Session;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\ResourceModel\Quote as QuoteResource;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @magentoAppArea frontend
+ * @magentoAppIsolation enabled
+ */
+class CheckoutDataTest extends TestCase
+{
+    private const EXISTING_PUBLIC_ORDER_ID = 'e5537d5a79264a53995b9ccf6b86225b46925006f6e24a59a8892fbb524b1aa0';
+
+    private const NEW_PUBLIC_ORDER_ID = 'aca5efca525f4748be5820d62d95c88b2e9b11b98bb643fc93b2109500a2f993';
+
+    /**
+     * @magentoConfigFixture current_website checkout/bold_checkout_payment_booster/shop_id test-shop-id
+     * @magentoConfigFixture current_website checkout/bold_checkout_payment_booster/is_payment_booster_enabled 1
+     * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/magento_quote_bold_order.php
+     */
+    public function testReplacesStalePublicOrderIdWhenQuoteAlreadyProcessed(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var Quote $quote */
+        $quote = $objectManager->create(Quote::class);
+        /** @var QuoteResource $quoteResource */
+        $quoteResource = $objectManager->create(QuoteResource::class);
+        /** @var Session $checkoutSession */
+        $checkoutSession = $objectManager->get(Session::class);
+        /** @var MagentoQuoteBoldOrderRepositoryInterface $magentoQuoteBoldOrderRepository */
+        $magentoQuoteBoldOrderRepository = $objectManager->create(MagentoQuoteBoldOrderRepositoryInterface::class);
+
+        $quoteResource->load($quote, 'test_order_item_with_items', 'reserved_order_id');
+        $quoteId = (string)$quote->getId();
+
+        $magentoQuoteBoldOrderRepository->saveStateAt($quoteId);
+
+        $checkoutSession->replaceQuote($quote);
+        $checkoutSession->setBoldCheckoutData(
+            [
+                'data' => [
+                    'public_order_id' => self::EXISTING_PUBLIC_ORDER_ID,
+                    'jwt_token' => 'stale-jwt-token',
+                ],
+            ]
+        );
+
+        /** @var ResumeOrder&MockObject $resumeOrder */
+        $resumeOrder = $this->createMock(ResumeOrder::class);
+        $resumeOrder
+            ->expects(self::never())
+            ->method('resume')
+            ->with(self::EXISTING_PUBLIC_ORDER_ID);
+
+        /** @var InitOrderFromQuote&MockObject $initOrderFromQuote */
+        $initOrderFromQuote = $this->createMock(InitOrderFromQuote::class);
+        $initOrderFromQuote
+            ->expects(self::once())
+            ->method('init')
+            ->with(self::identicalTo($quote))
+            ->willReturn(
+                [
+                    'data' => [
+                        'public_order_id' => self::NEW_PUBLIC_ORDER_ID,
+                        'jwt_token' => 'new-jwt-token',
+                        'flow_settings' => [],
+                    ],
+                ]
+            );
+
+        $this->registerCheckoutDataDependencies($objectManager, $resumeOrder, $initOrderFromQuote);
+
+        /** @var CheckoutData $checkoutData */
+        $checkoutData = $objectManager->create(CheckoutData::class);
+        $checkoutData->initCheckoutData();
+
+        self::assertNotSame(self::EXISTING_PUBLIC_ORDER_ID, $checkoutData->getPublicOrderId());
+        self::assertSame(self::NEW_PUBLIC_ORDER_ID, $checkoutData->getPublicOrderId());
+        self::assertSame('new-jwt-token', $checkoutData->getJwtToken());
+    }
+
+    /**
+     * @magentoConfigFixture current_website checkout/bold_checkout_payment_booster/shop_id test-shop-id
+     * @magentoConfigFixture current_website checkout/bold_checkout_payment_booster/is_payment_booster_enabled 1
+     * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/magento_quote_bold_order.php
+     */
+    public function testInitCheckoutDataResumesWhenQuoteNotProcessed(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var Quote $quote */
+        $quote = $objectManager->create(Quote::class);
+        /** @var QuoteResource $quoteResource */
+        $quoteResource = $objectManager->create(QuoteResource::class);
+        /** @var Session $checkoutSession */
+        $checkoutSession = $objectManager->get(Session::class);
+
+        $quoteResource->load($quote, 'test_order_item_with_items', 'reserved_order_id');
+        $websiteId = (int)$quote->getStore()->getWebsiteId();
+
+        $checkoutSession->replaceQuote($quote);
+        $checkoutSession->setBoldCheckoutData(
+            [
+                'data' => [
+                    'public_order_id' => self::EXISTING_PUBLIC_ORDER_ID,
+                    'jwt_token' => 'existing-jwt-token',
+                ],
+            ]
+        );
+
+        /** @var ResumeOrder&MockObject $resumeOrder */
+        $resumeOrder = $this->createMock(ResumeOrder::class);
+        $resumeOrder
+            ->expects(self::once())
+            ->method('resume')
+            ->with(self::EXISTING_PUBLIC_ORDER_ID, $websiteId)
+            ->willReturn(
+                [
+                    'data' => [
+                        'public_order_id' => self::EXISTING_PUBLIC_ORDER_ID,
+                        'jwt_token' => 'resumed-jwt-token',
+                    ],
+                ]
+            );
+
+        /** @var InitOrderFromQuote&MockObject $initOrderFromQuote */
+        $initOrderFromQuote = $this->createMock(InitOrderFromQuote::class);
+        $initOrderFromQuote->expects(self::never())->method('init');
+
+        $this->registerCheckoutDataDependencies($objectManager, $resumeOrder, $initOrderFromQuote);
+
+        /** @var CheckoutData $checkoutData */
+        $checkoutData = $objectManager->create(CheckoutData::class);
+        $checkoutData->initCheckoutData();
+
+        self::assertSame(self::EXISTING_PUBLIC_ORDER_ID, $checkoutData->getPublicOrderId());
+        self::assertSame('resumed-jwt-token', $checkoutData->getJwtToken());
+    }
+
+    /**
+     * @param \Magento\Framework\ObjectManagerInterface $objectManager
+     * @param ResumeOrder&MockObject $resumeOrder
+     * @param InitOrderFromQuote&MockObject $initOrderFromQuote
+     */
+    private function registerCheckoutDataDependencies(
+        $objectManager,
+        ResumeOrder $resumeOrder,
+        InitOrderFromQuote $initOrderFromQuote
+    ): void {
+        $getFastlaneStylesStub = $this->createStub(GetFastlaneStyles::class);
+        $getFastlaneStylesStub
+            ->method('getStyles')
+            ->willReturn([]);
+
+        $objectManager->configure(
+            [
+                ResumeOrder::class => [
+                    'shared' => true,
+                ],
+                InitOrderFromQuote::class => [
+                    'shared' => true,
+                ],
+                GetFastlaneStyles::class => [
+                    'shared' => true,
+                ],
+            ]
+        );
+        $objectManager->addSharedInstance($resumeOrder, ResumeOrder::class);
+        $objectManager->addSharedInstance($initOrderFromQuote, InitOrderFromQuote::class);
+        $objectManager->addSharedInstance($getFastlaneStylesStub, GetFastlaneStyles::class);
+    }
+}

--- a/Test/Integration/Model/Config/Backend/DigitalWallets/DeactivateQuotesTest.php
+++ b/Test/Integration/Model/Config/Backend/DigitalWallets/DeactivateQuotesTest.php
@@ -4,19 +4,19 @@ declare(strict_types=1);
 
 namespace Bold\CheckoutPaymentBooster\Test\Integration\Model\Config\Backend\DigitalWallets;
 
+use Bold\CheckoutPaymentBooster\Test\Integration\_Support\IntegrationTestCase;
 use Bold\CheckoutPaymentBooster\Observer\Checkout\ConfigureShopObserver;
 use Magento\Config\Model\Config;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\Config\ValueFactory;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\TestFramework\Helper\Bootstrap;
-use PHPUnit\Framework\TestCase;
 
 /**
  * @magentoAppIsolation enabled
  * @magentoAppArea adminhtml
  */
-class DeactivateQuotesTest extends TestCase
+class DeactivateQuotesTest extends IntegrationTestCase
 {
     public function testValidatesConfigurationSuccessfullyBeforeSaving(): void
     {

--- a/Test/Integration/Model/Log/OrderTrackerTest.php
+++ b/Test/Integration/Model/Log/OrderTrackerTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\CheckoutPaymentBooster\Test\Integration\Model\Log;
+
+use Bold\CheckoutPaymentBooster\Model\Config;
+use Bold\CheckoutPaymentBooster\Model\Log\OrderTracker;
+use Magento\Framework\Serialize\Serializer\Json;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class OrderTrackerTest extends TestCase
+{
+    private const PUBLIC_ORDER_ID = 'HoytrcPr1RDlbnlUxbgiXL4V489726qjj1g9Sm6P2xi2eSR4zUnWunfR9ageBBD7';
+
+    /**
+     * @var Config&MockObject
+     */
+    private $config;
+
+    /**
+     * @var LoggerInterface&MockObject
+     */
+    private $logger;
+
+    protected function setUp(): void
+    {
+        $this->config = $this->createMock(Config::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+    }
+
+    public function testTraceKeepsPublicOrderIdButSanitizesPii(): void
+    {
+        $this->config->method('getLogIsEnabled')->willReturn(true);
+
+        $logged = '';
+        $this->logger->expects(self::once())
+            ->method('info')
+            ->willReturnCallback(static function (string $message) use (&$logged): void {
+                $logged = $message;
+            });
+
+        $tracker = new OrderTracker($this->logger, $this->config, new Json());
+        $tracker->trace(1, 'hydrate_start', [
+            'quote_id' => '815438',
+            'public_order_id' => self::PUBLIC_ORDER_ID,
+            'customer_id' => 6683,
+            'grand_total' => 144.97,
+            'url' => 'checkout/orders/shop/' . self::PUBLIC_ORDER_ID . '/payments/auth/full',
+        ]);
+
+        self::assertStringContainsString(self::PUBLIC_ORDER_ID, $logged);
+        self::assertStringContainsString('"public_order_id":', $logged);
+        self::assertStringNotContainsString('6683', $logged);
+        self::assertStringNotContainsString('144.97', $logged);
+        self::assertStringContainsString('"checkout_ref":', $logged);
+        self::assertStringContainsString('"customer_logged_in":true', $logged);
+    }
+
+    public function testSamePublicOrderIdGrepableAcrossEvents(): void
+    {
+        $this->config->method('getLogIsEnabled')->willReturn(true);
+
+        $messages = [];
+        $this->logger->method('info')
+            ->willReturnCallback(static function (string $message) use (&$messages): void {
+                $messages[] = $message;
+            });
+
+        $tracker = new OrderTracker($this->logger, $this->config, new Json());
+        $tracker->trace(1, 'init_checkout_data_resumed', [
+            'quote_id' => '42',
+            'public_order_id' => self::PUBLIC_ORDER_ID,
+        ]);
+        $tracker->trace(1, 'auth_full_success', [
+            'quote_id' => '42',
+            'public_order_id' => self::PUBLIC_ORDER_ID,
+            'transaction_id' => '72D00553JH658592J',
+        ]);
+
+        self::assertCount(2, $messages);
+        self::assertStringContainsString(self::PUBLIC_ORDER_ID, $messages[0]);
+        self::assertStringContainsString(self::PUBLIC_ORDER_ID, $messages[1]);
+        self::assertStringContainsString('"txn_ref":', $messages[1]);
+        self::assertStringNotContainsString('72D00553JH658592J', $messages[1]);
+    }
+
+    public function testResolveEventKeepsDistinctPublicOrderIdSources(): void
+    {
+        $this->config->method('getLogIsEnabled')->willReturn(true);
+
+        $logged = '';
+        $this->logger->expects(self::once())
+            ->method('info')
+            ->willReturnCallback(static function (string $message) use (&$logged): void {
+                $logged = $message;
+            });
+
+        $sessionId = self::PUBLIC_ORDER_ID;
+        $extensionId = '7WYlBAN947oJKsRlDsU9c9beLiFtY6kRffiZ8iNinSYF9ptoIgpPIy1Iq4PzrHIL';
+
+        $tracker = new OrderTracker($this->logger, $this->config, new Json());
+        $tracker->trace(1, 'resolve_public_order_id', [
+            'quote_id' => '815438',
+            'session_public_order_id' => $sessionId,
+            'quote_ext_public_order_id' => $extensionId,
+            'db_public_order_id' => $sessionId,
+            'resolved_public_order_id' => $sessionId,
+            'public_order_ids_match' => false,
+        ]);
+
+        self::assertStringContainsString($sessionId, $logged);
+        self::assertStringContainsString($extensionId, $logged);
+        self::assertStringContainsString('"session_public_order_id":', $logged);
+        self::assertStringContainsString('"quote_ext_public_order_id":', $logged);
+        self::assertStringContainsString('"public_order_ids_match":false', $logged);
+    }
+
+    public function testTraceSkippedWhenLoggingDisabled(): void
+    {
+        $this->config->method('getLogIsEnabled')->willReturn(false);
+        $this->logger->expects(self::never())->method('info');
+
+        $tracker = new OrderTracker($this->logger, $this->config, new Json());
+        $tracker->trace(1, 'hydrate_start', ['public_order_id' => self::PUBLIC_ORDER_ID]);
+    }
+}

--- a/Test/Integration/Model/Order/HydrateOrderFromQuoteTest.php
+++ b/Test/Integration/Model/Order/HydrateOrderFromQuoteTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\CheckoutPaymentBooster\Test\Integration\Model\Order;
+
+use Bold\CheckoutPaymentBooster\Api\Data\Http\Client\ResultInterface;
+use Bold\CheckoutPaymentBooster\Api\MagentoQuoteBoldOrderRepositoryInterface;
+use Bold\CheckoutPaymentBooster\Model\Http\BoldClient;
+use Bold\CheckoutPaymentBooster\Model\Order\HydrateOrderFromQuote;
+use Bold\CheckoutPaymentBooster\Test\Integration\_Support\IntegrationTestCase;
+use Bold\CheckoutPaymentBooster\Test\Integration\_Support\NonBaseCurrencyQuoteTrait;
+use Magento\TestFramework\Helper\Bootstrap;
+
+class HydrateOrderFromQuoteTest extends IntegrationTestCase
+{
+    use NonBaseCurrencyQuoteTrait;
+
+    /**
+     * @dataProvider nonBaseDisplayCurrencyProvider
+     * @magentoDataFixture Magento/SalesRule/_files/cart_rule_with_coupon_5_off_no_condition.php
+     * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/quote_with_shipping_tax_and_discount.php
+     * @magentoDbIsolation enabled
+     */
+    public function testHydrateSendsBaseCurrencyAmountsForNonBaseCurrencyQuote(string $displayCurrency): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        $quote = $this->prepareQuoteWithDisplayCurrency('test_order_1', $displayCurrency);
+        $this->assertQuoteUsesNonBaseCurrency($quote, $displayCurrency);
+        $this->assertDisplayAndBaseGrandTotalsDiffer($quote);
+
+        $capturedBody = null;
+        $boldApiResultMock = $this->createMock(ResultInterface::class);
+        $boldApiResultMock->method('getStatus')->willReturn(201);
+
+        $boldClientMock = $this->createMock(BoldClient::class);
+        $boldClientMock->method('put')->willReturnCallback(
+            static function (int $websiteId, string $url, array $body) use ($boldApiResultMock, &$capturedBody) {
+                $capturedBody = $body;
+
+                return $boldApiResultMock;
+            }
+        );
+
+        $repositoryMock = $this->createMock(MagentoQuoteBoldOrderRepositoryInterface::class);
+        $repositoryMock->expects(self::once())->method('saveHydratedAt');
+
+        $hydrateOrderFromQuote = $objectManager->create(
+            HydrateOrderFromQuote::class,
+            [
+                'client' => $boldClientMock,
+                'magentoQuoteBoldOrderRepository' => $repositoryMock,
+            ]
+        );
+
+        $hydrateOrderFromQuote->hydrate($quote, 'test-public-order-id');
+
+        self::assertIsArray($capturedBody);
+        self::assertArrayHasKey('totals', $capturedBody);
+
+        $expectedOrderTotal = (int) round((float) $quote->getBaseGrandTotal() * 100);
+        $expectedSubTotal = (int) round((float) $quote->getBaseSubtotal() * 100);
+        $expectedTaxTotal = (int) round((float) ($quote->getShippingAddress()->getBaseTaxAmount() ?? 0) * 100);
+        $expectedShippingTotal = (int) round((float) $quote->getShippingAddress()->getBaseShippingAmount() * 100);
+
+        self::assertSame($expectedOrderTotal, $capturedBody['totals']['order_total']);
+        self::assertSame($expectedSubTotal, $capturedBody['totals']['sub_total']);
+        self::assertSame($expectedTaxTotal, $capturedBody['totals']['tax_total']);
+        self::assertSame($expectedShippingTotal, $capturedBody['totals']['shipping_total']);
+        self::assertNotSame(
+            (int) round((float) $quote->getGrandTotal() * 100),
+            $capturedBody['totals']['order_total'],
+            'Hydration must not send display-currency grand total when quote currency differs from base'
+        );
+    }
+}

--- a/Test/Integration/Model/Order/ResolvePublicOrderIdTest.php
+++ b/Test/Integration/Model/Order/ResolvePublicOrderIdTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\CheckoutPaymentBooster\Test\Integration\Model\Order;
+
+use Bold\CheckoutPaymentBooster\Api\MagentoQuoteBoldOrderRepositoryInterface;
+use Bold\CheckoutPaymentBooster\Model\Order\ResolvePublicOrderId;
+use Magento\Checkout\Model\Session;
+use Magento\Quote\Api\Data\CartExtensionInterface;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\ResourceModel\Quote as QuoteResource;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @magentoAppArea frontend
+ * @magentoAppIsolation enabled
+ */
+class ResolvePublicOrderIdTest extends TestCase
+{
+    /**
+     * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/magento_quote_bold_order.php
+     */
+    public function testPrefersSessionIdOverStaleExtensionIdWhenQuoteIsProcessed(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var MagentoQuoteBoldOrderRepositoryInterface $repository */
+        $repository = $objectManager->create(MagentoQuoteBoldOrderRepositoryInterface::class);
+        /** @var Session $checkoutSession */
+        $checkoutSession = $objectManager->get(Session::class);
+        /** @var Quote $quote */
+        $quote = $objectManager->create(Quote::class);
+        /** @var QuoteResource $quoteResource */
+        $quoteResource = $objectManager->create(QuoteResource::class);
+
+        $quoteResource->load($quote, 'test_order_item_with_items', 'reserved_order_id');
+        $quoteId = (string)$quote->getId();
+
+        $repository->saveStateAt($quoteId);
+
+        $checkoutSession->replaceQuote($quote);
+        $checkoutSession->setBoldCheckoutData(['data' => ['public_order_id' => 'session-public-order-id']]);
+
+        /** @var CartExtensionInterface $extensionAttributes */
+        $extensionAttributes = $quote->getExtensionAttributes();
+        $extensionAttributes->setBoldOrderId('stale-extension-id');
+
+        /** @var ResolvePublicOrderId $resolvePublicOrderId */
+        $resolvePublicOrderId = $objectManager->create(ResolvePublicOrderId::class);
+
+        self::assertSame('session-public-order-id', $resolvePublicOrderId->execute($quote));
+    }
+
+    /**
+     * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/magento_quote_bold_order.php
+     */
+    public function testReconcilesStaleExtensionIdToSessionForActiveQuote(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var MagentoQuoteBoldOrderRepositoryInterface $repository */
+        $repository = $objectManager->create(MagentoQuoteBoldOrderRepositoryInterface::class);
+        /** @var Session $checkoutSession */
+        $checkoutSession = $objectManager->get(Session::class);
+        /** @var Quote $quote */
+        $quote = $objectManager->create(Quote::class);
+        /** @var QuoteResource $quoteResource */
+        $quoteResource = $objectManager->create(QuoteResource::class);
+
+        $quoteResource->load($quote, 'test_order_item_with_items', 'reserved_order_id');
+        $quoteId = (string)$quote->getId();
+
+        $checkoutSession->replaceQuote($quote);
+        $checkoutSession->setBoldCheckoutData(['data' => ['public_order_id' => 'session-public-order-id']]);
+
+        /** @var CartExtensionInterface $extensionAttributes */
+        $extensionAttributes = $quote->getExtensionAttributes();
+        $extensionAttributes->setBoldOrderId('stale-extension-id');
+
+        /** @var ResolvePublicOrderId $resolvePublicOrderId */
+        $resolvePublicOrderId = $objectManager->create(ResolvePublicOrderId::class);
+
+        self::assertSame('session-public-order-id', $resolvePublicOrderId->execute($quote));
+        self::assertSame('session-public-order-id', $extensionAttributes->getBoldOrderId());
+        self::assertSame(
+            'session-public-order-id',
+            $repository->getByQuoteId($quoteId)->getBoldOrderId()
+        );
+    }
+
+    /**
+     * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/magento_quote_bold_order.php
+     */
+    public function testUsesExtensionIdWhenSessionIsEmpty(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var Quote $quote */
+        $quote = $objectManager->create(Quote::class);
+        /** @var QuoteResource $quoteResource */
+        $quoteResource = $objectManager->create(QuoteResource::class);
+
+        $quoteResource->load($quote, 'test_order_item_with_items', 'reserved_order_id');
+
+        /** @var CartExtensionInterface $extensionAttributes */
+        $extensionAttributes = $quote->getExtensionAttributes();
+        $extensionAttributes->setBoldOrderId('extension-only-id');
+
+        /** @var ResolvePublicOrderId $resolvePublicOrderId */
+        $resolvePublicOrderId = $objectManager->create(ResolvePublicOrderId::class);
+
+        self::assertSame('extension-only-id', $resolvePublicOrderId->execute($quote));
+    }
+
+    /**
+     * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/magento_quote_bold_order.php
+     */
+    public function testTreatsEmptyExtensionIdAsNullAndUsesSession(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var Session $checkoutSession */
+        $checkoutSession = $objectManager->get(Session::class);
+        /** @var Quote $quote */
+        $quote = $objectManager->create(Quote::class);
+        /** @var QuoteResource $quoteResource */
+        $quoteResource = $objectManager->create(QuoteResource::class);
+
+        $quoteResource->load($quote, 'test_order_item_with_items', 'reserved_order_id');
+
+        $checkoutSession->replaceQuote($quote);
+        $checkoutSession->setBoldCheckoutData(['data' => ['public_order_id' => 'session-public-order-id']]);
+
+        /** @var CartExtensionInterface $extensionAttributes */
+        $extensionAttributes = $quote->getExtensionAttributes();
+        $extensionAttributes->setBoldOrderId('');
+
+        /** @var ResolvePublicOrderId $resolvePublicOrderId */
+        $resolvePublicOrderId = $objectManager->create(ResolvePublicOrderId::class);
+
+        self::assertSame('session-public-order-id', $resolvePublicOrderId->execute($quote));
+    }
+}

--- a/Test/Integration/Model/Quote/GetCartLineItemsTest.php
+++ b/Test/Integration/Model/Quote/GetCartLineItemsTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\CheckoutPaymentBooster\Test\Integration\Model\Quote;
+
+use Bold\CheckoutPaymentBooster\Model\Quote\GetCartLineItems;
+use Bold\CheckoutPaymentBooster\Test\Integration\_Support\IntegrationTestCase;
+use Bold\CheckoutPaymentBooster\Test\Integration\_Support\NonBaseCurrencyQuoteTrait;
+use Magento\Quote\Model\Quote\Item;
+use Magento\TestFramework\Helper\Bootstrap;
+
+class GetCartLineItemsTest extends IntegrationTestCase
+{
+    use NonBaseCurrencyQuoteTrait;
+
+    /**
+     * @dataProvider nonBaseDisplayCurrencyProvider
+     * @magentoDataFixture Magento/SalesRule/_files/cart_rule_with_coupon_5_off_no_condition.php
+     * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/quote_with_shipping_tax_and_discount.php
+     * @magentoDbIsolation enabled
+     */
+    public function testGetItemsUsesBasePricesForNonBaseCurrencyQuote(string $displayCurrency): void
+    {
+        $quote = $this->prepareQuoteWithDisplayCurrency('test_order_1', $displayCurrency);
+        $this->assertQuoteUsesNonBaseCurrency($quote, $displayCurrency);
+        $this->assertDisplayAndBaseGrandTotalsDiffer($quote);
+
+        $getCartLineItems = Bootstrap::getObjectManager()->get(GetCartLineItems::class);
+        $lineItems = $getCartLineItems->getItems($quote);
+
+        self::assertNotEmpty($lineItems);
+
+        /** @var Item $quoteItem */
+        $quoteItem = $quote->getAllVisibleItems()[0];
+        $expectedPriceCents = (int) round((float) $quoteItem->getBasePrice() * 100);
+
+        self::assertSame($expectedPriceCents, $lineItems[0]['price']);
+    }
+}

--- a/Test/Integration/Model/SessionReuseTest.php
+++ b/Test/Integration/Model/SessionReuseTest.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\CheckoutPaymentBooster\Test\Integration\Model;
+
+use Bold\CheckoutPaymentBooster\Api\Data\Http\Client\ResultInterface;
+use Bold\CheckoutPaymentBooster\Api\MagentoQuoteBoldOrderRepositoryInterface;
+use Bold\CheckoutPaymentBooster\Model\CheckoutData;
+use Bold\CheckoutPaymentBooster\Model\Eps\GetFastlaneStyles;
+use Bold\CheckoutPaymentBooster\Model\Http\BoldClient;
+use Bold\CheckoutPaymentBooster\Model\InitOrderFromQuote;
+use Bold\CheckoutPaymentBooster\Model\Order\OrderExtensionData;
+use Bold\CheckoutPaymentBooster\Model\Order\OrderExtensionDataFactory;
+use Bold\CheckoutPaymentBooster\Model\Order\SetCompleteState;
+use Bold\CheckoutPaymentBooster\Model\OrderExtensionDataRepository;
+use Bold\CheckoutPaymentBooster\Model\ResumeOrder;
+use Magento\Checkout\Model\Session;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\ResourceModel\Quote as QuoteResource;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\ResourceModel\Order as OrderResource;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression tests for CHK-9605: reusing the same public_order_id on a completed DW quote.
+ *
+ * @magentoAppArea frontend
+ * @magentoAppIsolation enabled
+ */
+class SessionReuseTest extends TestCase
+{
+    private const STALE_PUBLIC_ORDER_ID = 'e5537d5a79264a53995b9ccf6b86225b46925006f6e24a59a8892fbb524b1aa0';
+
+    private const NEW_PUBLIC_ORDER_ID = 'aca5efca525f4748be5820d62d95c88b2e9b11b98bb643fc93b2109500a2f993';
+
+    /**
+     * Ozeparts smoking-gun path: order #1 completed, same quote reused, stale session ID must not resume.
+     *
+     * @magentoConfigFixture current_website checkout/bold_checkout_payment_booster/shop_id test-shop-id
+     * @magentoConfigFixture current_website checkout/bold_checkout_payment_booster/is_payment_booster_enabled 1
+     * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/magento_quote_bold_order.php
+     */
+    public function testSecondCheckoutReplacesStalePublicOrderIdOnProcessedQuote(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var Quote $quote */
+        $quote = $objectManager->create(Quote::class);
+        /** @var QuoteResource $quoteResource */
+        $quoteResource = $objectManager->create(QuoteResource::class);
+        /** @var Session $checkoutSession */
+        $checkoutSession = $objectManager->get(Session::class);
+        /** @var MagentoQuoteBoldOrderRepositoryInterface $magentoQuoteBoldOrderRepository */
+        $magentoQuoteBoldOrderRepository = $objectManager->create(MagentoQuoteBoldOrderRepositoryInterface::class);
+        /** @var CartRepositoryInterface $cartRepository */
+        $cartRepository = $objectManager->create(CartRepositoryInterface::class);
+
+        $quoteResource->load($quote, 'test_order_item_with_items', 'reserved_order_id');
+        $quoteId = (string)$quote->getId();
+
+        // Simulate order #1 order_complete: quote marked processed, bold_order_id cleared.
+        $magentoQuoteBoldOrderRepository->saveStateAt($quoteId);
+        $relation = $magentoQuoteBoldOrderRepository->getByQuoteId($quoteId);
+        $relation->setBoldOrderId('');
+        $magentoQuoteBoldOrderRepository->save($relation);
+
+        self::assertTrue($magentoQuoteBoldOrderRepository->isQuoteProcessed($quoteId));
+
+        // Stale Bold session from order #1 (the bug would resume this ID).
+        $checkoutSession->replaceQuote($quote);
+        $checkoutSession->setBoldCheckoutData(
+            [
+                'data' => [
+                    'public_order_id' => self::STALE_PUBLIC_ORDER_ID,
+                    'jwt_token' => 'stale-jwt-token',
+                ],
+            ]
+        );
+
+        /** @var ResumeOrder&MockObject $resumeOrder */
+        $resumeOrder = $this->createMock(ResumeOrder::class);
+        $resumeOrder
+            ->expects(self::never())
+            ->method('resume')
+            ->with(self::STALE_PUBLIC_ORDER_ID);
+
+        /** @var InitOrderFromQuote&MockObject $initOrderFromQuote */
+        $initOrderFromQuote = $this->createMock(InitOrderFromQuote::class);
+        $initOrderFromQuote
+            ->expects(self::once())
+            ->method('init')
+            ->with(self::identicalTo($quote))
+            ->willReturn(
+                [
+                    'data' => [
+                        'public_order_id' => self::NEW_PUBLIC_ORDER_ID,
+                        'jwt_token' => 'new-jwt-token',
+                        'flow_settings' => [],
+                    ],
+                ]
+            );
+
+        $this->registerCheckoutDataDependencies($objectManager, $resumeOrder, $initOrderFromQuote);
+
+        /** @var CheckoutData $checkoutData */
+        $checkoutData = $objectManager->create(CheckoutData::class);
+        $checkoutData->initCheckoutData();
+
+        self::assertNotSame(self::STALE_PUBLIC_ORDER_ID, $checkoutData->getPublicOrderId());
+        self::assertSame(self::NEW_PUBLIC_ORDER_ID, $checkoutData->getPublicOrderId());
+
+        $reloadedQuote = $cartRepository->get((int)$quoteId);
+        self::assertNull($reloadedQuote->getExtensionAttributes()->getBoldOrderId());
+    }
+
+    /**
+     * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/magento_quote_bold_order.php
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testOrderCompleteClearsBoldOrderIdOnQuoteRelation(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var Quote $quote */
+        $quote = $objectManager->create(Quote::class);
+        /** @var QuoteResource $quoteResource */
+        $quoteResource = $objectManager->create(QuoteResource::class);
+        /** @var Order $order */
+        $order = $objectManager->create(Order::class);
+        /** @var OrderResource $orderResource */
+        $orderResource = $objectManager->create(OrderResource::class);
+        /** @var OrderRepositoryInterface $orderRepository */
+        $orderRepository = $objectManager->get(OrderRepositoryInterface::class);
+        /** @var OrderExtensionDataFactory $orderExtensionDataFactory */
+        $orderExtensionDataFactory = $objectManager->get(OrderExtensionDataFactory::class);
+        /** @var OrderExtensionDataRepository $orderExtensionDataRepository */
+        $orderExtensionDataRepository = $objectManager->get(OrderExtensionDataRepository::class);
+        /** @var MagentoQuoteBoldOrderRepositoryInterface $magentoQuoteBoldOrderRepository */
+        $magentoQuoteBoldOrderRepository = $objectManager->create(MagentoQuoteBoldOrderRepositoryInterface::class);
+
+        $quoteResource->load($quote, 'test_order_item_with_items', 'reserved_order_id');
+        $quoteId = (string)$quote->getId();
+
+        $orderResource->load($order, '100000001', 'increment_id');
+        $order->setQuoteId($quote->getId());
+        $orderRepository->save($order);
+
+        /** @var OrderExtensionData $orderExtensionData */
+        $orderExtensionData = $orderExtensionDataFactory->create();
+        $orderExtensionData->setOrderId((int)$order->getEntityId());
+        $orderExtensionData->setPublicId(self::STALE_PUBLIC_ORDER_ID);
+        $orderExtensionDataRepository->save($orderExtensionData);
+
+        $boldApiResultMock = $this->createMock(ResultInterface::class);
+        $boldApiResultMock->method('getStatus')->willReturn(201);
+
+        /** @var BoldClient&MockObject $boldClientMock */
+        $boldClientMock = $this->createMock(BoldClient::class);
+        $boldClientMock
+            ->expects(self::once())
+            ->method('put')
+            ->willReturn($boldApiResultMock);
+
+        /** @var SetCompleteState $setCompleteState */
+        $setCompleteState = $objectManager->create(
+            SetCompleteState::class,
+            [
+                'client' => $boldClientMock,
+            ]
+        );
+        $setCompleteState->execute($order);
+
+        $relation = $magentoQuoteBoldOrderRepository->getByQuoteId($quoteId);
+        self::assertTrue($relation->isProcessed());
+        self::assertSame('', $relation->getBoldOrderId());
+        self::assertNotSame(self::STALE_PUBLIC_ORDER_ID, $relation->getBoldOrderId());
+    }
+
+    /**
+     * @magentoDataFixture Magento/Checkout/_files/quote_with_address.php
+     * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/digital_wallets_quote.php
+     */
+    public function testDigitalWalletQuotePreservationClearsStaleBoldSessionData(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var Quote $regularQuote */
+        $regularQuote = $objectManager->create(Quote::class);
+        /** @var Quote $digitalWalletsQuote */
+        $digitalWalletsQuote = $objectManager->create(Quote::class);
+        /** @var QuoteResource $quoteResource */
+        $quoteResource = $objectManager->create(QuoteResource::class);
+        /** @var Session $checkoutSession */
+        $checkoutSession = $objectManager->get(Session::class);
+
+        $quoteResource->load($regularQuote, 'test_order_1', 'reserved_order_id');
+        $quoteResource->load($digitalWalletsQuote, 'digital_wallets_order_1', 'reserved_order_id');
+
+        $checkoutSession->replaceQuote($regularQuote);
+        $checkoutSession->setLastQuoteId($digitalWalletsQuote->getId());
+        $checkoutSession->setBoldCheckoutData(
+            [
+                'data' => [
+                    'public_order_id' => self::STALE_PUBLIC_ORDER_ID,
+                    'jwt_token' => 'stale-jwt-token',
+                ],
+            ]
+        );
+
+        $checkoutSession->clearQuote();
+
+        self::assertTrue($checkoutSession->hasQuote());
+        self::assertNull($checkoutSession->getBoldCheckoutData());
+    }
+
+    /**
+     * @param \Magento\Framework\ObjectManagerInterface $objectManager
+     * @param ResumeOrder&MockObject $resumeOrder
+     * @param InitOrderFromQuote&MockObject $initOrderFromQuote
+     */
+    private function registerCheckoutDataDependencies(
+        $objectManager,
+        ResumeOrder $resumeOrder,
+        InitOrderFromQuote $initOrderFromQuote
+    ): void {
+        $getFastlaneStylesStub = $this->createStub(GetFastlaneStyles::class);
+        $getFastlaneStylesStub
+            ->method('getStyles')
+            ->willReturn([]);
+
+        $objectManager->configure(
+            [
+                ResumeOrder::class => [
+                    'shared' => true,
+                ],
+                InitOrderFromQuote::class => [
+                    'shared' => true,
+                ],
+                GetFastlaneStyles::class => [
+                    'shared' => true,
+                ],
+            ]
+        );
+        $objectManager->addSharedInstance($resumeOrder, ResumeOrder::class);
+        $objectManager->addSharedInstance($initOrderFromQuote, InitOrderFromQuote::class);
+        $objectManager->addSharedInstance($getFastlaneStylesStub, GetFastlaneStyles::class);
+    }
+}

--- a/Test/Integration/Plugin/Booster/Service/DigitalWallets/MagentoQuote/CreatorPluginTest.php
+++ b/Test/Integration/Plugin/Booster/Service/DigitalWallets/MagentoQuote/CreatorPluginTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Bold\CheckoutPaymentBooster\Test\Integration\Plugin\Booster\Service\DigitalWallets\MagentoQuote;
 
+use Bold\CheckoutPaymentBooster\Test\Integration\_Support\IntegrationTestCase;
+use Bold\CheckoutPaymentBooster\Test\Integration\_Support\NonBaseCurrencyQuoteTrait;
 use Bold\CheckoutPaymentBooster\Model\CheckoutData;
 use Bold\CheckoutPaymentBooster\Plugin\Booster\Service\DigitalWallets\MagentoQuote\CreatorPlugin;
 use Bold\CheckoutPaymentBooster\Service\DigitalWallets\MagentoQuote\Creator;
@@ -12,14 +14,14 @@ use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Quote\Api\Data\CartExtensionInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\TestFramework\Helper\Bootstrap;
-use PHPUnit\Framework\TestCase;
 
 /**
  * @magentoAppIsolation enabled
  */
-class CreatorPluginTest extends TestCase
+class CreatorPluginTest extends IntegrationTestCase
 {
     use AssertPluginIsConfiguredCorrectly;
+    use NonBaseCurrencyQuoteTrait;
 
     private const PLUGIN_NAME = 'bold_booster_reinit_order_data';
 
@@ -78,6 +80,46 @@ class CreatorPluginTest extends TestCase
         self::assertSame(
             'aca5efca525f4748be5820d62d95c88b2e9b11b98bb643fc93b2109500a2f993',
             $cartExtension->getBoldOrderId()
+        );
+    }
+
+    /**
+     * @dataProvider nonBaseDisplayCurrencyProvider
+     * @magentoDbIsolation enabled
+     * @magentoAppArea frontend
+     * @magentoDataFixture Magento/Catalog/_files/product_virtual.php
+     * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/magento_quote_bold_order.php
+     */
+    public function testReinitializesBoldOrderDataWithNonBaseCurrencyQuote(string $displayCurrency): void
+    {
+        $boldCheckoutDataStub = $this->createStub(CheckoutData::class);
+        $objectManager = Bootstrap::getObjectManager();
+        $storeManager = $objectManager->get(StoreManagerInterface::class);
+        $productRepository = $objectManager->create(ProductRepositoryInterface::class);
+        $product = $productRepository->get('virtual-product');
+        $productRequestData = [
+            'bold_order_id' => 'e5537d5a79264a53995b9ccf6b86225b46925006f6e24a59a8892fbb524b1aa0',
+            'qty' => 1,
+        ];
+        $magentoQuoteCreator = $objectManager->create(Creator::class);
+
+        $boldCheckoutDataStub->method('resetCheckoutData')->willReturn(null);
+        $boldCheckoutDataStub->method('initCheckoutData')->willReturn(null);
+        $boldCheckoutDataStub->method('getPublicOrderId')
+            ->willReturn('aca5efca525f4748be5820d62d95c88b2e9b11b98bb643fc93b2109500a2f993');
+
+        $objectManager->configure([CheckoutData::class => ['shared' => true]]);
+        $objectManager->addSharedInstance($boldCheckoutDataStub, CheckoutData::class);
+
+        $this->setStoreDisplayCurrency($displayCurrency, (int) $storeManager->getStore()->getId());
+
+        $result = $magentoQuoteCreator->createQuote($storeManager->getStore()->getId(), $product, $productRequestData);
+        $quote = $this->applyDisplayCurrencyToQuote($result['quote'], $displayCurrency);
+        $this->assertQuoteUsesNonBaseCurrency($quote, $displayCurrency);
+
+        self::assertSame(
+            'aca5efca525f4748be5820d62d95c88b2e9b11b98bb643fc93b2109500a2f993',
+            $result['quote']->getExtensionAttributes()->getBoldOrderId()
         );
     }
 

--- a/Test/Integration/Plugin/Checkout/Model/SessionPluginTest.php
+++ b/Test/Integration/Plugin/Checkout/Model/SessionPluginTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Bold\CheckoutPaymentBooster\Test\Integration\Plugin\Checkout\Model;
 
+use Bold\CheckoutPaymentBooster\Model\CheckoutData;
 use Bold\CheckoutPaymentBooster\Plugin\Checkout\Model\SessionPlugin;
 use Bold\CheckoutPaymentBooster\Test\Integration\_Assertions\AssertPluginIsConfiguredCorrectly;
 use Magento\Checkout\Model\Session;
@@ -35,7 +36,21 @@ class SessionPluginTest extends TestCase
      */
     public function testDoesNotClearSessionIfLastQuoteIsDigitalWalletsQuote(): void
     {
+        $checkoutDataMock = $this->createMock(CheckoutData::class);
+        $checkoutDataMock
+            ->expects(self::once())
+            ->method('resetCheckoutData');
+
         $objectManager = Bootstrap::getObjectManager();
+        $objectManager->configure(
+            [
+                CheckoutData::class => [
+                    'shared' => true,
+                ],
+            ]
+        );
+        $objectManager->addSharedInstance($checkoutDataMock, CheckoutData::class);
+
         /** @var Quote $regularQuote */
         $regularQuote = $objectManager->create(Quote::class);
         /** @var Quote $digitalWalletsQuote */

--- a/Test/Integration/Plugin/Checkout/Model/SessionPluginTest.php
+++ b/Test/Integration/Plugin/Checkout/Model/SessionPluginTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Bold\CheckoutPaymentBooster\Test\Integration\Plugin\Checkout\Model;
 
+use Bold\CheckoutPaymentBooster\Test\Integration\_Support\IntegrationTestCase;
+use Bold\CheckoutPaymentBooster\Model\CheckoutData;
 use Bold\CheckoutPaymentBooster\Plugin\Checkout\Model\SessionPlugin;
 use Bold\CheckoutPaymentBooster\Test\Integration\_Assertions\AssertPluginIsConfiguredCorrectly;
 use Magento\Checkout\Model\Session;
@@ -16,7 +18,7 @@ use PHPUnit\Framework\TestCase;
  * @magentoAppArea frontend
  * @magentoAppIsolation enabled
  */
-class SessionPluginTest extends TestCase
+class SessionPluginTest extends IntegrationTestCase
 {
     use AssertPluginIsConfiguredCorrectly;
 
@@ -35,7 +37,21 @@ class SessionPluginTest extends TestCase
      */
     public function testDoesNotClearSessionIfLastQuoteIsDigitalWalletsQuote(): void
     {
+        $checkoutDataMock = $this->createMock(CheckoutData::class);
+        $checkoutDataMock
+            ->expects(self::once())
+            ->method('resetCheckoutData');
+
         $objectManager = Bootstrap::getObjectManager();
+        $objectManager->configure(
+            [
+                CheckoutData::class => [
+                    'shared' => true,
+                ],
+            ]
+        );
+        $objectManager->addSharedInstance($checkoutDataMock, CheckoutData::class);
+
         /** @var Quote $regularQuote */
         $regularQuote = $objectManager->create(Quote::class);
         /** @var Quote $digitalWalletsQuote */

--- a/Test/Integration/Plugin/Framework/App/ActionInterfacePluginTest.php
+++ b/Test/Integration/Plugin/Framework/App/ActionInterfacePluginTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Bold\CheckoutPaymentBooster\Test\Integration\Plugin\Framework\App;
 
+use Bold\CheckoutPaymentBooster\Test\Integration\_Support\IntegrationTestCase;
 use Bold\CheckoutPaymentBooster\Plugin\Framework\App\ActionInterfacePlugin;
 use Bold\CheckoutPaymentBooster\Test\Integration\_Assertions\AssertPluginIsConfiguredCorrectly;
 use Magento\Customer\Model\ResourceModel\CustomerRepository;
@@ -12,9 +13,8 @@ use Magento\Framework\App\ActionInterface;
 use Magento\Framework\App\Http\Context as HttpContext;
 use Magento\Framework\App\TestStubs\InterfaceOnlyFrontendAction;
 use Magento\TestFramework\Helper\Bootstrap;
-use PHPUnit\Framework\TestCase;
 
-class ActionInterfacePluginTest extends TestCase
+class ActionInterfacePluginTest extends IntegrationTestCase
 {
     use AssertPluginIsConfiguredCorrectly;
 

--- a/Test/Integration/Plugin/Payment/Model/Checks/CanUseCheckoutPluginTest.php
+++ b/Test/Integration/Plugin/Payment/Model/Checks/CanUseCheckoutPluginTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Bold\CheckoutPaymentBooster\Test\Integration\Plugin\Payment\Model\Checks;
 
+use Bold\CheckoutPaymentBooster\Test\Integration\_Support\IntegrationTestCase;
+use Bold\CheckoutPaymentBooster\Test\Integration\_Support\NonBaseCurrencyQuoteTrait;
 use Bold\CheckoutPaymentBooster\Model\MagentoQuoteBoldOrder;
 use Bold\CheckoutPaymentBooster\Model\Payment\Gateway\Service as PaymentGatewayService;
 use Bold\CheckoutPaymentBooster\Model\ResourceModel\MagentoQuoteBoldOrder as MagentoQuoteBoldOrderResourceModel;
@@ -16,11 +18,11 @@ use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Quote\Api\Data\CartInterface;
 use Magento\Quote\Model\Quote;
 use Magento\TestFramework\Helper\Bootstrap;
-use PHPUnit\Framework\TestCase;
 
-class CanUseCheckoutPluginTest extends TestCase
+class CanUseCheckoutPluginTest extends IntegrationTestCase
 {
     use AssertPluginIsConfiguredCorrectly;
+    use NonBaseCurrencyQuoteTrait;
 
     private const PLUGIN_NAME = 'bold_booster_can_use_checkout_digital_wallets';
 
@@ -74,6 +76,37 @@ class CanUseCheckoutPluginTest extends TestCase
         $isApplicable = $canUseCheckout->isApplicable($paymentMethodStub, $quote);
 
         self::assertTrue($isApplicable);
+    }
+
+    /**
+     * @dataProvider nonBaseDisplayCurrencyProvider
+     * @magentoDbIsolation enabled
+     * @magentoAppArea frontend
+     * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/magento_quote_bold_order.php
+     * @throws NoSuchEntityException
+     */
+    public function testIsApplicableForBoldOrderWithNonBaseCurrencyQuote(string $displayCurrency): void
+    {
+        $paymentMethodStub = $this->createStub(MethodInterface::class);
+        $objectManager = Bootstrap::getObjectManager();
+        $magentoQuoteBoldOrder = $objectManager->create(MagentoQuoteBoldOrder::class);
+        $magentoQuoteBoldOrderResourceModel = $objectManager->create(MagentoQuoteBoldOrderResourceModel::class);
+        $cartRepository = $objectManager->create(CartRepositoryInterface::class);
+        $canUseCheckout = $objectManager->create(CanUseCheckout::class);
+
+        $paymentMethodStub->method('getCode')->willReturn(PaymentGatewayService::CODE);
+        $magentoQuoteBoldOrderResourceModel->load(
+            $magentoQuoteBoldOrder,
+            'e5537d5a79264a53995b9ccf6b86225b46925006f6e24a59a8892fbb524b1aa0',
+            'bold_order_id'
+        );
+
+        $quote = $cartRepository->get((int) $magentoQuoteBoldOrder->getQuoteId());
+        $quote = $this->applyDisplayCurrencyToQuote($quote, $displayCurrency);
+        $quote = $this->persistQuote($quote);
+        $this->assertQuoteUsesNonBaseCurrency($quote, $displayCurrency);
+
+        self::assertTrue($canUseCheckout->isApplicable($paymentMethodStub, $quote));
     }
 
     /**

--- a/Test/Integration/Plugin/Quote/Api/CartRepositoryInterfacePluginTest.php
+++ b/Test/Integration/Plugin/Quote/Api/CartRepositoryInterfacePluginTest.php
@@ -8,6 +8,8 @@ use Bold\CheckoutPaymentBooster\Api\MagentoQuoteBoldOrderRepositoryInterface;
 use Bold\CheckoutPaymentBooster\Model\MagentoQuoteBoldOrder;
 use Bold\CheckoutPaymentBooster\Model\ResourceModel\MagentoQuoteBoldOrder as MagentoQuoteBoldOrderResourceModel;
 use Bold\CheckoutPaymentBooster\Plugin\Quote\Api\CartRepositoryInterfacePlugin;
+use Bold\CheckoutPaymentBooster\Test\Integration\_Support\IntegrationTestCase;
+use Bold\CheckoutPaymentBooster\Test\Integration\_Support\NonBaseCurrencyQuoteTrait;
 use Bold\CheckoutPaymentBooster\Test\Integration\_Assertions\AssertPluginIsConfiguredCorrectly;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Quote\Api\CartRepositoryInterface;
@@ -15,11 +17,11 @@ use Magento\Quote\Api\Data\CartInterface;
 use Magento\Quote\Model\Quote;
 use Magento\Quote\Model\ResourceModel\Quote as CartResourceModel;
 use Magento\TestFramework\Helper\Bootstrap;
-use PHPUnit\Framework\TestCase;
 
-class CartRepositoryInterfacePluginTest extends TestCase
+class CartRepositoryInterfacePluginTest extends IntegrationTestCase
 {
     use AssertPluginIsConfiguredCorrectly;
+    use NonBaseCurrencyQuoteTrait;
 
     private const PLUGIN_NAME = 'bold_booster_add_public_order_id';
 
@@ -77,6 +79,37 @@ class CartRepositoryInterfacePluginTest extends TestCase
     }
 
     /**
+     * @dataProvider nonBaseDisplayCurrencyProvider
+     * @magentoDbIsolation enabled
+     * @magentoAppArea frontend
+     * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/magento_quote_bold_order.php
+     * @throws NoSuchEntityException
+     */
+    public function testRetrievesBoldOrderIdAfterCartRetrievalWithNonBaseCurrencyQuote(string $displayCurrency): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        $magentoQuoteBoldOrder = $objectManager->create(MagentoQuoteBoldOrder::class);
+        $magentoQuoteBoldOrderResourceModel = $objectManager->create(MagentoQuoteBoldOrderResourceModel::class);
+        $cartRepository = $objectManager->create(CartRepositoryInterface::class);
+
+        $magentoQuoteBoldOrderResourceModel->load(
+            $magentoQuoteBoldOrder,
+            'e5537d5a79264a53995b9ccf6b86225b46925006f6e24a59a8892fbb524b1aa0',
+            'bold_order_id'
+        );
+
+        $quote = $cartRepository->get((int) $magentoQuoteBoldOrder->getQuoteId());
+        $quote = $this->applyDisplayCurrencyToQuote($quote, $displayCurrency);
+        $quote = $this->persistQuote($quote);
+        $this->assertQuoteUsesNonBaseCurrency($quote, $displayCurrency);
+
+        self::assertSame(
+            'e5537d5a79264a53995b9ccf6b86225b46925006f6e24a59a8892fbb524b1aa0',
+            $quote->getExtensionAttributes()->getBoldOrderId()
+        );
+    }
+
+    /**
      * @magentoAppArea frontend
      * @magentoDataFixture Magento/Checkout/_files/quote_with_items_saved.php
      * @throws NoSuchEntityException
@@ -109,5 +142,36 @@ class CartRepositoryInterfacePluginTest extends TestCase
             'ad4b1b411a7a45538bfcb48cadb9af0e9fc92360c2574ca29b0099377007d6bc',
             $magentoQuoteBoldOrder->getBoldOrderId()
         );
+    }
+
+    /**
+     * @magentoAppArea frontend
+     * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/magento_quote_bold_order.php
+     * @throws NoSuchEntityException
+     */
+    public function testDoesNotExposeClearedBoldOrderIdAfterCartRetrieval(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var MagentoQuoteBoldOrder $magentoQuoteBoldOrder */
+        $magentoQuoteBoldOrder = $objectManager->create(MagentoQuoteBoldOrder::class);
+        /** @var MagentoQuoteBoldOrderResourceModel $magentoQuoteBoldOrderResourceModel */
+        $magentoQuoteBoldOrderResourceModel = $objectManager->create(MagentoQuoteBoldOrderResourceModel::class);
+        /** @var MagentoQuoteBoldOrderRepositoryInterface $magentoQuoteBoldOrderRepository */
+        $magentoQuoteBoldOrderRepository = $objectManager->create(MagentoQuoteBoldOrderRepositoryInterface::class);
+        /** @var CartRepositoryInterface $cartRepository */
+        $cartRepository = $objectManager->create(CartRepositoryInterface::class);
+
+        $magentoQuoteBoldOrderResourceModel->load(
+            $magentoQuoteBoldOrder,
+            'e5537d5a79264a53995b9ccf6b86225b46925006f6e24a59a8892fbb524b1aa0',
+            'bold_order_id'
+        );
+
+        $magentoQuoteBoldOrder->setBoldOrderId('');
+        $magentoQuoteBoldOrderRepository->save($magentoQuoteBoldOrder);
+
+        $cart = $cartRepository->get((int)$magentoQuoteBoldOrder->getQuoteId());
+
+        self::assertNull($cart->getExtensionAttributes()->getBoldOrderId());
     }
 }

--- a/Test/Integration/Plugin/Quote/Api/CartRepositoryInterfacePluginTest.php
+++ b/Test/Integration/Plugin/Quote/Api/CartRepositoryInterfacePluginTest.php
@@ -110,4 +110,35 @@ class CartRepositoryInterfacePluginTest extends TestCase
             $magentoQuoteBoldOrder->getBoldOrderId()
         );
     }
+
+    /**
+     * @magentoAppArea frontend
+     * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/magento_quote_bold_order.php
+     * @throws NoSuchEntityException
+     */
+    public function testDoesNotExposeClearedBoldOrderIdAfterCartRetrieval(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var MagentoQuoteBoldOrder $magentoQuoteBoldOrder */
+        $magentoQuoteBoldOrder = $objectManager->create(MagentoQuoteBoldOrder::class);
+        /** @var MagentoQuoteBoldOrderResourceModel $magentoQuoteBoldOrderResourceModel */
+        $magentoQuoteBoldOrderResourceModel = $objectManager->create(MagentoQuoteBoldOrderResourceModel::class);
+        /** @var MagentoQuoteBoldOrderRepositoryInterface $magentoQuoteBoldOrderRepository */
+        $magentoQuoteBoldOrderRepository = $objectManager->create(MagentoQuoteBoldOrderRepositoryInterface::class);
+        /** @var CartRepositoryInterface $cartRepository */
+        $cartRepository = $objectManager->create(CartRepositoryInterface::class);
+
+        $magentoQuoteBoldOrderResourceModel->load(
+            $magentoQuoteBoldOrder,
+            'e5537d5a79264a53995b9ccf6b86225b46925006f6e24a59a8892fbb524b1aa0',
+            'bold_order_id'
+        );
+
+        $magentoQuoteBoldOrder->setBoldOrderId('');
+        $magentoQuoteBoldOrderRepository->save($magentoQuoteBoldOrder);
+
+        $cart = $cartRepository->get((int)$magentoQuoteBoldOrder->getQuoteId());
+
+        self::assertNull($cart->getExtensionAttributes()->getBoldOrderId());
+    }
 }

--- a/Test/Integration/Service/DigitalWallets/MagentoQuote/CreatorTest.php
+++ b/Test/Integration/Service/DigitalWallets/MagentoQuote/CreatorTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Bold\CheckoutPaymentBooster\Test\Integration\Service\DigitalWallets\MagentoQuote;
 
+use Bold\CheckoutPaymentBooster\Test\Integration\_Support\IntegrationTestCase;
+use Bold\CheckoutPaymentBooster\Test\Integration\_Support\NonBaseCurrencyQuoteTrait;
 use Bold\CheckoutPaymentBooster\Service\DigitalWallets\MagentoQuote\Creator;
 use DateTimeImmutable;
 use Exception;
@@ -27,14 +29,15 @@ use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Model\QuoteIdMaskFactory;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\TestFramework\Helper\Bootstrap;
-use PHPUnit\Framework\TestCase;
 
 use function __;
 use function array_rand;
 use function reset;
 
-class CreatorTest extends TestCase
+class CreatorTest extends IntegrationTestCase
 {
+    use NonBaseCurrencyQuoteTrait;
+
     /**
      * @magentoDataFixture Magento/Catalog/_files/product_simple.php
      */
@@ -88,6 +91,63 @@ class CreatorTest extends TestCase
             $productRequestData
         );
 
+        self::assertInstanceOf(CartInterface::class, $quote);
+        self::assertNotNull($quote->getId());
+        self::assertNotEmpty($maskedId);
+    }
+
+    /**
+     * @dataProvider nonBaseDisplayCurrencyProvider
+     * @magentoDbIsolation enabled
+     * @magentoDataFixture Magento/Catalog/_files/product_simple.php
+     */
+    public function testCreatesQuoteSuccessfullyForSimpleProductWithNonBaseCurrency(string $displayCurrency): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        $productRepository = $objectManager->create(ProductRepositoryInterface::class);
+        $product = $productRepository->get('simple');
+        $productOptions = [];
+        $dateTime = new DateTimeImmutable();
+        $productRequestData = [
+            'product' => $product->getId(),
+        ];
+        $storeManager = $objectManager->get(StoreManagerInterface::class);
+        $magentoQuoteCreator = $objectManager->create(Creator::class);
+        $this->setStoreDisplayCurrency($displayCurrency, (int) $storeManager->getStore()->getId());
+
+        foreach ($product->getOptions() ?? [] as $productOption) {
+            switch ($productOption->getType()) {
+                case 'field':
+                    $productOptions[$productOption->getOptionId()] = 'test';
+                    break;
+                case 'date_time':
+                    $productOptions[$productOption->getOptionId()] = [
+                        'day' => $dateTime->format('d'),
+                        'month' => $dateTime->format('m'),
+                        'year' => $dateTime->format('Y'),
+                        'hour' => $dateTime->format('H'),
+                        'minute' => $dateTime->format('i'),
+                    ];
+                    break;
+                case 'drop_down':
+                case 'radio':
+                    $productOptions[$productOption->getOptionId()] = array_rand($productOption->getValues() ?? []);
+                    break;
+                default:
+                    throw new Exception('Unsupported product option type "' . $productOption->getType() . '"');
+            }
+        }
+
+        $productRequestData['options'] = $productOptions;
+
+        ['quote' => $createdQuote, 'maskedId' => $maskedId] = $magentoQuoteCreator->createQuote(
+            $storeManager->getStore()->getId(),
+            $product,
+            $productRequestData
+        );
+
+        $quote = $this->applyDisplayCurrencyToQuote($createdQuote, $displayCurrency);
+        $this->assertQuoteUsesNonBaseCurrency($quote, $displayCurrency);
         self::assertInstanceOf(CartInterface::class, $quote);
         self::assertNotNull($quote->getId());
         self::assertNotEmpty($maskedId);

--- a/Test/Integration/Service/DigitalWallets/MagentoQuote/DeactivatorTest.php
+++ b/Test/Integration/Service/DigitalWallets/MagentoQuote/DeactivatorTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Bold\CheckoutPaymentBooster\Test\Integration\Service\DigitalWallets\MagentoQuote;
 
+use Bold\CheckoutPaymentBooster\Test\Integration\_Support\IntegrationTestCase;
+use Bold\CheckoutPaymentBooster\Test\Integration\_Support\NonBaseCurrencyQuoteTrait;
 use Bold\CheckoutPaymentBooster\Service\DigitalWallets\MagentoQuote\Deactivator;
 use Bold\CheckoutPaymentBooster\Test\Integration\_Stubs\Magento\Quote\Model\ResourceModel\Quote\CollectionStub
     as QuoteCollectionStub;
@@ -21,13 +23,14 @@ use Magento\Quote\Model\ResourceModel\Quote as QuoteResourceModel;
 use Magento\Quote\Model\ResourceModel\Quote\Collection as QuoteCollection;
 use Magento\Quote\Model\ResourceModel\Quote\CollectionFactory as QuoteCollectionFactory;
 use Magento\TestFramework\Helper\Bootstrap;
-use PHPUnit\Framework\TestCase;
 
 use function class_exists;
 use function count;
 
-class DeactivatorTest extends TestCase
+class DeactivatorTest extends IntegrationTestCase
 {
+    use NonBaseCurrencyQuoteTrait;
+
     /**
      * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/magento_quote_bold_order.php
      */
@@ -57,6 +60,27 @@ class DeactivatorTest extends TestCase
         $deactivatedQuote = $cartRepository->get((int)$quoteId);
 
         self::assertFalse((bool)$deactivatedQuote->getIsActive());
+    }
+
+    /**
+     * @dataProvider nonBaseDisplayCurrencyProvider
+     * @magentoDbIsolation enabled
+     * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/magento_quote_bold_order.php
+     */
+    public function testDeactivatesNonBaseCurrencyQuoteSuccessfully(string $displayCurrency): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        $cartRepository = $objectManager->create(CartRepositoryInterface::class);
+        $quoteDeactivator = $objectManager->create(Deactivator::class);
+
+        $quote = $this->prepareQuoteWithDisplayCurrency('test_order_item_with_items', $displayCurrency, true);
+        $this->assertQuoteUsesNonBaseCurrency($quote, $displayCurrency);
+        $quote->setData('is_digital_wallets', true);
+        $this->persistQuote($quote);
+
+        $quoteDeactivator->deactivateQuote((int) $quote->getId());
+
+        self::assertFalse((bool) $cartRepository->get((int) $quote->getId())->getIsActive());
     }
 
     public function testThrowsExceptionIfQuoteIdIsInvalid(): void

--- a/Test/Integration/Service/DigitalWallets/MagentoQuote/TotalsRetrieverTest.php
+++ b/Test/Integration/Service/DigitalWallets/MagentoQuote/TotalsRetrieverTest.php
@@ -17,6 +17,8 @@ class TotalsRetrieverTest extends IntegrationTestCase
 {
     use NonBaseCurrencyQuoteTrait;
 
+    private const NON_EXISTENT_QUOTE_ID = 999999999;
+
     /**
      * @magentoDataFixture Magento/Checkout/_files/quote_with_items_saved.php
      */
@@ -71,12 +73,12 @@ class TotalsRetrieverTest extends IntegrationTestCase
 
     public function testThrowsExceptionForInvalidQuoteId(): void
     {
-        $this->expectExceptionMessage('No such entity with cartId = 42');
+        $this->expectExceptionMessage('No such entity with cartId = ' . self::NON_EXISTENT_QUOTE_ID);
 
         $objectManager = Bootstrap::getObjectManager();
         /** @var TotalsRetriever $totalsRetriever */
         $totalsRetriever = $objectManager->create(TotalsRetriever::class);
 
-        $totalsRetriever->retrieveTotals(42);
+        $totalsRetriever->retrieveTotals(self::NON_EXISTENT_QUOTE_ID);
     }
 }

--- a/Test/Integration/Service/DigitalWallets/MagentoQuote/TotalsRetrieverTest.php
+++ b/Test/Integration/Service/DigitalWallets/MagentoQuote/TotalsRetrieverTest.php
@@ -4,16 +4,19 @@ declare(strict_types=1);
 
 namespace Bold\CheckoutPaymentBooster\Test\Integration\Service\DigitalWallets\MagentoQuote;
 
+use Bold\CheckoutPaymentBooster\Test\Integration\_Support\IntegrationTestCase;
+use Bold\CheckoutPaymentBooster\Test\Integration\_Support\NonBaseCurrencyQuoteTrait;
 use Bold\CheckoutPaymentBooster\Service\DigitalWallets\MagentoQuote\TotalsRetriever;
 use Magento\Quote\Model\Quote;
 use Magento\Quote\Model\ResourceModel\Quote as QuoteResourceModel;
 use Magento\TestFramework\Helper\Bootstrap;
-use PHPUnit\Framework\TestCase;
 
 use function count;
 
-class TotalsRetrieverTest extends TestCase
+class TotalsRetrieverTest extends IntegrationTestCase
 {
+    use NonBaseCurrencyQuoteTrait;
+
     /**
      * @magentoDataFixture Magento/Checkout/_files/quote_with_items_saved.php
      */
@@ -43,6 +46,27 @@ class TotalsRetrieverTest extends TestCase
             self::assertArrayHasKey($key, $actualTotals);
             self::assertEquals($expectedValue, $actualTotals[$key], "Totals key '{$key}' mismatch.");
         }
+    }
+
+    /**
+     * @dataProvider nonBaseDisplayCurrencyProvider
+     * @magentoDbIsolation enabled
+     * @magentoDataFixture Magento/Checkout/_files/quote_with_items_saved.php
+     */
+    public function testRetrievesQuoteItemTotalsWithNonBaseCurrencyQuote(string $displayCurrency): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        $quote = $this->prepareQuoteWithDisplayCurrency('test_order_item_with_items', $displayCurrency, true);
+        $totalsRetriever = $objectManager->create(TotalsRetriever::class);
+
+        $this->assertQuoteUsesNonBaseCurrency($quote, $displayCurrency);
+        $this->assertDisplayAndBaseGrandTotalsDiffer($quote);
+
+        $actualTotals = $totalsRetriever->retrieveTotals($quote->getId());
+
+        self::assertEquals($quote->getGrandTotal(), $actualTotals['grand_total']);
+        self::assertEquals($quote->getBaseGrandTotal(), $actualTotals['base_grand_total']);
+        self::assertNotEquals($actualTotals['grand_total'], $actualTotals['base_grand_total']);
     }
 
     public function testThrowsExceptionForInvalidQuoteId(): void

--- a/Test/Integration/Service/ExpressPay/Order/CreateTest.php
+++ b/Test/Integration/Service/ExpressPay/Order/CreateTest.php
@@ -7,6 +7,8 @@ namespace Bold\CheckoutPaymentBooster\Test\Integration\Service\ExpressPay\Order;
 use Bold\CheckoutPaymentBooster\Api\Data\Http\Client\ResultInterface;
 use Bold\CheckoutPaymentBooster\Model\Http\BoldClient;
 use Bold\CheckoutPaymentBooster\Service\ExpressPay\Order\Create;
+use Bold\CheckoutPaymentBooster\Test\Integration\_Support\IntegrationTestCase;
+use Bold\CheckoutPaymentBooster\Test\Integration\_Support\NonBaseCurrencyQuoteTrait;
 use Exception;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\Exception\LocalizedException;
@@ -18,12 +20,13 @@ use Magento\Quote\Model\QuoteIdToMaskedQuoteIdInterface;
 use Magento\Quote\Model\QuoteRepository;
 use Magento\Quote\Model\ResourceModel\Quote\Item as QuoteItemResource;
 use Magento\TestFramework\Helper\Bootstrap;
-use PHPUnit\Framework\TestCase;
 
 use function reset;
 
-class CreateTest extends TestCase
+class CreateTest extends IntegrationTestCase
 {
+    use NonBaseCurrencyQuoteTrait;
+
     /**
      * @var Quote|null
      */
@@ -86,6 +89,69 @@ class CreateTest extends TestCase
         );
 
         self::assertSame($expectedResultData, $actualResultData);
+    }
+
+    /**
+     * @dataProvider nonBaseDisplayCurrencyProvider
+     * @magentoDbIsolation enabled
+     * @magentoDataFixture Magento/ConfigurableProduct/_files/tax_rule.php
+     * @magentoDataFixture Magento/SalesRule/_files/cart_rule_with_coupon_5_off_no_condition.php
+     * @magentoDataFixture Magento/Catalog/_files/product_simple.php
+     * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/quote_with_shipping_tax_and_discount.php
+     */
+    public function testCreatesExpressPayOrderWithNonBaseCurrencyQuote(string $displayCurrency): void
+    {
+        $capturedBody = null;
+        $boldApiResultMock = $this->createMock(ResultInterface::class);
+        $boldClientMock = $this->createMock(BoldClient::class);
+        $objectManager = Bootstrap::getObjectManager();
+        $createExpressPayOrderService = $objectManager->create(
+            Create::class,
+            [
+                'httpClient' => $boldClientMock,
+            ]
+        );
+        $quote = $this->prepareQuoteWithDisplayCurrency('test_order_1', $displayCurrency, true);
+        $this->assertQuoteUsesNonBaseCurrency($quote, $displayCurrency);
+        $this->assertDisplayAndBaseGrandTotalsDiffer($quote);
+        $quoteMaskId = $this->getQuoteMaskId($quote);
+
+        $boldApiResultMock->method('getBody')
+            ->willReturn(
+                [
+                    'data' => [
+                        'order_id' => '5d23799a-0c98-4147-914e-abd1b84aab82',
+                    ],
+                ]
+            );
+        $boldApiResultMock->method('getErrors')->willReturn([]);
+        $boldApiResultMock->method('getStatus')->willReturn(200);
+
+        $boldClientMock->method('post')
+            ->willReturnCallback(
+                static function (int $websiteId, string $url, array $body) use ($boldApiResultMock, &$capturedBody) {
+                    $capturedBody = $body;
+
+                    return $boldApiResultMock;
+                }
+            );
+
+        $createExpressPayOrderService->execute(
+            $quoteMaskId,
+            'ff152513-f548-11ef-b987-3a475e3f6277',
+            'e4403e69-1fd2-4d8a-be28-fdbf911a20bb',
+            'dynamic',
+            false,
+            ''
+        );
+
+        self::assertIsArray($capturedBody);
+        self::assertArrayHasKey('order_data', $capturedBody);
+        $this->assertOrderDataUsesBaseCurrency($capturedBody['order_data']);
+        self::assertSame(
+            number_format((float) $quote->getBaseGrandTotal(), 2, '.', ''),
+            $capturedBody['order_data']['amount']['value']
+        );
     }
 
     public function testDoesNotCreateExpressPayOrderIfQuoteMaskIdIsInvalid(): void
@@ -393,9 +459,9 @@ class CreateTest extends TestCase
         );
     }
 
-    private function getQuote(): \Magento\Quote\Api\Data\CartInterface
+    private function getQuote(string $fixture = 'default'): \Magento\Quote\Api\Data\CartInterface
     {
-        if ($this->quote !== null) {
+        if ($this->quote !== null && $fixture === 'default') {
             return $this->quote;
         }
 
@@ -419,17 +485,22 @@ class CreateTest extends TestCase
 
         $quote = $cartRepository->get((int)$quote->getId());
 
-        return $this->quote = $quote;
+        if ($fixture === 'default') {
+            $this->quote = $quote;
+        }
+
+        return $quote;
     }
 
-    private function getQuoteMaskId(): string
+    private function getQuoteMaskId(?Quote $quote = null): string
     {
         /** @var ObjectManagerInterface $objectManager */
         $objectManager = Bootstrap::getObjectManager();
         /** @var QuoteIdToMaskedQuoteIdInterface $quoteIdToMaskedQuoteId */
         $quoteIdToMaskedQuoteId = $objectManager->create(QuoteIdToMaskedQuoteIdInterface::class);
+        $quote = $quote ?? $this->getQuote();
         /** @var int|string|null $quoteId */
-        $quoteId = $this->getQuote()->getId();
+        $quoteId = $quote->getId();
 
         try {
             $quoteMaskId = $quoteIdToMaskedQuoteId->execute((int)$quoteId);

--- a/Test/Integration/Service/ExpressPay/Order/GetTest.php
+++ b/Test/Integration/Service/ExpressPay/Order/GetTest.php
@@ -6,14 +6,14 @@ namespace Bold\CheckoutPaymentBooster\Test\Integration\Service\ExpressPay\Order;
 
 use Bold\CheckoutPaymentBooster\Api\Data\Http\Client\ResultInterface;
 use Bold\CheckoutPaymentBooster\Model\Http\BoldClient;
+use Bold\CheckoutPaymentBooster\Test\Integration\_Support\IntegrationTestCase;
 use Bold\CheckoutPaymentBooster\Service\ExpressPay\Order\Get;
 use Exception;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\TestFramework\Helper\Bootstrap;
-use PHPUnit\Framework\TestCase;
 
-class GetTest extends TestCase
+class GetTest extends IntegrationTestCase
 {
     /**
      * @throws LocalizedException

--- a/Test/Integration/Service/ExpressPay/Order/UpdateTest.php
+++ b/Test/Integration/Service/ExpressPay/Order/UpdateTest.php
@@ -10,6 +10,8 @@ use Bold\CheckoutPaymentBooster\Api\Data\Http\Client\ResultInterface;
 use Bold\CheckoutPaymentBooster\Model\Http\BoldClient;
 use Bold\CheckoutPaymentBooster\Service\ExpressPay\Order\Get as GetExpressPayOrder;
 use Bold\CheckoutPaymentBooster\Service\ExpressPay\Order\Update;
+use Bold\CheckoutPaymentBooster\Test\Integration\_Support\IntegrationTestCase;
+use Bold\CheckoutPaymentBooster\Test\Integration\_Support\NonBaseCurrencyQuoteTrait;
 use Exception;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\Exception\LocalizedException;
@@ -20,13 +22,14 @@ use Magento\Quote\Api\Data\CartInterface;
 use Magento\Quote\Model\Quote;
 use Magento\Quote\Model\QuoteIdToMaskedQuoteIdInterface;
 use Magento\TestFramework\Helper\Bootstrap;
-use PHPUnit\Framework\TestCase;
 
 use function __;
 use function reset;
 
-class UpdateTest extends TestCase
+class UpdateTest extends IntegrationTestCase
 {
+    use NonBaseCurrencyQuoteTrait;
+
     /**
      * @var Quote|null
      */
@@ -95,6 +98,76 @@ class UpdateTest extends TestCase
             '472df0908785478d8509fbfa8ef532eb',
             'dynamic'
         );
+    }
+
+    /**
+     * @dataProvider nonBaseDisplayCurrencyProvider
+     * @magentoDbIsolation enabled
+     * @magentoDataFixture Magento/ConfigurableProduct/_files/tax_rule.php
+     * @magentoDataFixture Magento/SalesRule/_files/cart_rule_with_coupon_5_off_no_condition.php
+     * @magentoDataFixture Magento/Catalog/_files/product_simple.php
+     * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/quote_with_shipping_tax_and_discount.php
+     * @throws LocalizedException
+     */
+    public function testUpdatesExpressPayOrderWithNonBaseCurrencyQuote(string $displayCurrency): void
+    {
+        $capturedBody = null;
+        $objectManager = Bootstrap::getObjectManager();
+        $expressPayOrderShippingAddress = $objectManager->create(
+            AddressInterface::class,
+            [
+                'data' => [
+                    'country' => 'US',
+                    'city' => 'CityM',
+                ],
+            ]
+        );
+        $expressPayOrder = $objectManager->create(
+            OrderInterface::class,
+            [
+                'data' => [
+                    'shipping_address' => $expressPayOrderShippingAddress,
+                ],
+            ]
+        );
+        $getExpressPayOrderMock = $this->createMock(GetExpressPayOrder::class);
+        $boldApiResultMock = $this->createMock(ResultInterface::class);
+        $boldClientMock = $this->createMock(BoldClient::class);
+        $updateExpressPayOrderService = $objectManager->create(
+            Update::class,
+            [
+                'getExpressPayOrder' => $getExpressPayOrderMock,
+                'httpClient' => $boldClientMock,
+            ]
+        );
+
+        $quote = $this->prepareQuoteWithDisplayCurrency('test_order_1', $displayCurrency, true);
+        $this->assertQuoteUsesNonBaseCurrency($quote, $displayCurrency);
+        $this->assertDisplayAndBaseGrandTotalsDiffer($quote);
+        $quoteMaskId = $this->getQuoteMaskId($quote);
+
+        $getExpressPayOrderMock->method('execute')->willReturn($expressPayOrder);
+        $boldApiResultMock->method('getErrors')->willReturn([]);
+        $boldApiResultMock->method('getStatus')->willReturn(204);
+        $boldClientMock->method('patch')
+            ->willReturnCallback(
+                static function (int $websiteId, string $url, array $body) use ($boldApiResultMock, &$capturedBody) {
+                    $capturedBody = $body;
+
+                    return $boldApiResultMock;
+                }
+            );
+
+        $updateExpressPayOrderService->execute(
+            $quoteMaskId,
+            'e08fac5cffd6467389ce3aac1df1eeeb',
+            '472df0908785478d8509fbfa8ef532eb',
+            'dynamic'
+        );
+
+        self::assertIsArray($capturedBody);
+        self::assertArrayHasKey('order_data', $capturedBody);
+        $this->assertOrderDataUsesBaseCurrency($capturedBody['order_data']);
     }
 
     public function testDoesNotUpdateExpressPayOrderIfQuoteMaskIdIsInvalid(): void
@@ -416,9 +489,9 @@ class UpdateTest extends TestCase
         ];
     }
 
-    private function getQuote(): Quote
+    private function getQuote(bool $resetState = false): Quote
     {
-        if ($this->quote !== null) {
+        if ($this->quote !== null && !$resetState) {
             return $this->quote;
         }
 
@@ -435,18 +508,24 @@ class UpdateTest extends TestCase
             ->getItems();
         /** @var Quote $quote */
         $quote = reset($quotes) ?: $objectManager->create(CartInterface::class);
+        $quote = $cartRepository->get((int) $quote->getId());
 
-        return $this->quote = $quote;
+        if (!$resetState) {
+            $this->quote = $quote;
+        }
+
+        return $quote;
     }
 
-    private function getQuoteMaskId(): string
+    private function getQuoteMaskId(?Quote $quote = null): string
     {
         /** @var ObjectManagerInterface $objectManager */
         $objectManager = Bootstrap::getObjectManager();
         /** @var QuoteIdToMaskedQuoteIdInterface $quoteIdToMaskedQuoteId */
         $quoteIdToMaskedQuoteId = $objectManager->create(QuoteIdToMaskedQuoteIdInterface::class);
+        $quote = $quote ?? $this->getQuote();
         /** @var int|string|null $quoteId */
-        $quoteId = $this->getQuote()->getId();
+        $quoteId = $quote->getId();
 
         try {
             $quoteMaskId = $quoteIdToMaskedQuoteId->execute((int)$quoteId);

--- a/Test/Integration/Service/ExpressPay/QuoteConverterTest.php
+++ b/Test/Integration/Service/ExpressPay/QuoteConverterTest.php
@@ -6,6 +6,8 @@ namespace Bold\CheckoutPaymentBooster\Test\Integration\Service\ExpressPay;
 
 use Bold\CheckoutPaymentBooster\Model\Config;
 use Bold\CheckoutPaymentBooster\Service\ExpressPay\QuoteConverter;
+use Bold\CheckoutPaymentBooster\Test\Integration\_Support\IntegrationTestCase;
+use Bold\CheckoutPaymentBooster\Test\Integration\_Support\NonBaseCurrencyQuoteTrait;
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\Api\SearchCriteriaInterface;
@@ -19,14 +21,15 @@ use Magento\Quote\Model\Quote\Address\RateResult\Error as AddressRateResultError
 use Magento\Quote\Model\Quote\Item;
 use Magento\Tax\Model\Calculation\Rule;
 use Magento\TestFramework\Helper\Bootstrap;
-use PHPUnit\Framework\TestCase;
 
 use function array_filter;
 use function array_walk;
 use function reset;
 
-class QuoteConverterTest extends TestCase
+class QuoteConverterTest extends IntegrationTestCase
 {
+    use NonBaseCurrencyQuoteTrait;
+
     /**
      * Converts the fixture quote (guest, one simple product, shipping, tax, coupon) and asserts
      * all order_data sections match the quote-derived expectations. Uses key-by-key assertions
@@ -57,12 +60,16 @@ class QuoteConverterTest extends TestCase
         $quote->getShippingAddress()->setCollectShippingRates(true);
         $quote->collectTotals();
 
-        $currencyCode = $quote->getCurrency() !== null
-            ? ($quote->getCurrency()->getQuoteCurrencyCode() ?? 'USD')
-            : 'USD';
-        $grandTotal   = number_format((float) $quote->getGrandTotal(), 2, '.', '');
-        $taxTotal     = number_format((float) ($quote->getShippingAddress()->getTaxAmount() ?? 0.0), 2, '.', '');
-        $shippingAmt  = number_format((float) $quote->getShippingAddress()->getShippingAmount(), 2, '.', '');
+        $currencyCode = $quote->getBaseCurrencyCode() ?? 'USD';
+        $grandTotal   = number_format((float) $quote->getBaseGrandTotal(), 2, '.', '');
+        $taxTotal     = number_format((float) ($quote->getShippingAddress()->getBaseTaxAmount() ?? 0.0), 2, '.', '');
+        $shippingAmt  = number_format((float) $quote->getShippingAddress()->getBaseShippingAmount(), 2, '.', '');
+        $discountAmt  = number_format(
+            abs((float) ($quote->getShippingAddress()->getBaseDiscountAmount() ?? 0.0)),
+            2,
+            '.',
+            ''
+        );
 
         $gatewayId = 'a31a8fd6-a9e2-4c68-a834-54567bfeb4b7';
         $expected = [
@@ -107,7 +114,7 @@ class QuoteConverterTest extends TestCase
                 'item_total' => ['currency_code' => $currencyCode, 'value' => '10.00'],
                 'amount'     => ['currency_code' => $currencyCode, 'value' => $grandTotal],
                 'tax_total'  => ['currency_code' => $currencyCode, 'value' => $taxTotal],
-                'discount'   => ['currency_code' => $currencyCode, 'value' => '5.00'],
+                'discount'   => ['currency_code' => $currencyCode, 'value' => $discountAmt],
             ],
         ];
 
@@ -126,10 +133,18 @@ class QuoteConverterTest extends TestCase
         self::assertEqualsCanonicalizing($expected['order_data']['customer'], $od['customer'], 'customer');
 
         self::assertArrayHasKey('shipping_address', $od);
-        self::assertEqualsCanonicalizing($expected['order_data']['shipping_address'], $od['shipping_address'], 'shipping_address');
+        self::assertEqualsCanonicalizing(
+            $expected['order_data']['shipping_address'],
+            $od['shipping_address'],
+            'shipping_address'
+        );
 
         self::assertArrayHasKey('selected_shipping_option', $od);
-        self::assertEqualsCanonicalizing($expected['order_data']['selected_shipping_option'], $od['selected_shipping_option'], 'selected_shipping_option');
+        self::assertEqualsCanonicalizing(
+            $expected['order_data']['selected_shipping_option'],
+            $od['selected_shipping_option'],
+            'selected_shipping_option'
+        );
 
         self::assertArrayHasKey('shipping_options', $od);
         self::assertIsArray($od['shipping_options']);
@@ -137,7 +152,11 @@ class QuoteConverterTest extends TestCase
         $found = false;
         foreach ($od['shipping_options'] as $opt) {
             if (isset($opt['id']) && $opt['id'] === 'flatrate_flatrate') {
-                self::assertEqualsCanonicalizing($expected['order_data']['shipping_options'][0], $opt, 'flatrate shipping option');
+                self::assertEqualsCanonicalizing(
+                    $expected['order_data']['shipping_options'][0],
+                    $opt,
+                    'flatrate shipping option'
+                );
                 $found = true;
                 break;
             }
@@ -202,6 +221,27 @@ class QuoteConverterTest extends TestCase
             ->setEmail('customer@example.com');
 
         $cartRepository->save($quote);
+        $quote = $cartRepository->get((int) $quote->getId());
+        $quote->collectTotals();
+
+        $discountAmt = number_format(
+            abs((float) ($quote->getBillingAddress()->getBaseDiscountAmount() ?? 0.0)),
+            2,
+            '.',
+            ''
+        );
+        $grandTotal = number_format((float) $quote->getBaseGrandTotal(), 2, '.', '');
+        $taxTotal = number_format(
+            (float) array_sum(
+                array_map(
+                    static fn (Item $item): float => (float) ($item->getBaseTaxAmount() ?? 0.0),
+                    $quote->getAllItems()
+                )
+            ),
+            2,
+            '.',
+            ''
+        );
 
         $expectedConvertedQuoteData = [
             'gateway_id' => 'a31a8fd6-a9e2-4c68-a834-54567bfeb4b7',
@@ -227,7 +267,7 @@ class QuoteConverterTest extends TestCase
                 ],
                 'amount' => [
                     'currency_code' => 'USD',
-                    'value' => '5.50'
+                    'value' => $grandTotal
                 ],
                 'item_total' => [
                     'currency_code' => 'USD',
@@ -235,11 +275,11 @@ class QuoteConverterTest extends TestCase
                 ],
                 'tax_total' => [
                     'currency_code' => 'USD',
-                    'value' => '0.50'
+                    'value' => $taxTotal
                 ],
                 'discount' => [
                     'currency_code' => 'USD',
-                    'value' => '5.00'
+                    'value' => $discountAmt
                 ]
             ]
         ];
@@ -255,48 +295,37 @@ class QuoteConverterTest extends TestCase
 
     /**
      * Same structure as testConvertFullQuoteConvertsNonVirtualQuote but for a quote in a non-base
-     * currency (EUR). Fixture builds from quote_with_shipping_tax_and_discount then sets EUR;
-     * we load the quote, derive expected values from it, call convertFullQuote, and assert by key.
+     * display currency. Fixture builds from quote_with_shipping_tax_and_discount; each data-provider
+     * row applies EUR display currency before convertFullQuote.
      *
-     * @magentoConfigFixture current_store currency/options/base USD
-     * @magentoConfigFixture current_store currency/options/default USD
-     * @magentoConfigFixture current_store currency/options/allow USD,EUR
-     * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/quote_non_base_currency.php
+     * @dataProvider nonBaseDisplayCurrencyProvider
+     * @magentoDataFixture Magento/SalesRule/_files/cart_rule_with_coupon_5_off_no_condition.php
+     * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/quote_with_shipping_tax_and_discount.php
+     * @magentoDbIsolation enabled
      */
-    public function testConvertFullQuoteConvertsNonBaseCurrencyQuote(): void
+    public function testConvertFullQuoteConvertsNonBaseCurrencyQuote(string $displayCurrency): void
     {
         $objectManager = Bootstrap::getObjectManager();
-        $cartRepository = $objectManager->get(CartRepositoryInterface::class);
-        $searchCriteria = $objectManager->create(SearchCriteriaBuilder::class)
-            ->addFilter('reserved_order_id', 'test_order_1')
-            ->create();
-        $quotes = $cartRepository->getList($searchCriteria)->getItems();
-        self::assertNotEmpty($quotes, 'Fixture quote with reserved_order_id test_order_1 not found');
-        /** @var Quote $quote */
-        $quote = $cartRepository->get((int) reset($quotes)->getId());
+        $quote = $this->prepareQuoteWithDisplayCurrency('test_order_1', $displayCurrency);
+        $this->assertQuoteUsesNonBaseCurrency($quote, $displayCurrency);
+        $this->assertDisplayAndBaseGrandTotalsDiffer($quote);
 
-        $productRepository = $objectManager->get(ProductRepositoryInterface::class);
-        foreach ($quote->getAllItems() as $item) {
-            if (!$item->getProduct()) {
-                $item->setProduct($productRepository->getById((int) $item->getProductId()));
-            }
-        }
-        $quote->getShippingAddress()->setCollectShippingRates(true);
-        $quote->collectTotals();
-
-        $currencyCode = $quote->getCurrency() !== null
-            ? ($quote->getCurrency()->getQuoteCurrencyCode() ?? 'EUR')
-            : 'EUR';
-        $grandTotal   = number_format((float) $quote->getGrandTotal(), 2, '.', '');
-        $taxTotal     = number_format((float) ($quote->getShippingAddress()->getTaxAmount() ?? 0.0), 2, '.', '');
-        $shippingAmt  = number_format((float) $quote->getShippingAddress()->getShippingAmount(), 2, '.', '');
+        $currencyCode = $quote->getBaseCurrencyCode() ?? 'USD';
+        $grandTotal   = number_format((float) $quote->getBaseGrandTotal(), 2, '.', '');
+        $taxTotal     = number_format((float) ($quote->getShippingAddress()->getBaseTaxAmount() ?? 0.0), 2, '.', '');
+        $shippingAmt  = number_format((float) $quote->getShippingAddress()->getBaseShippingAmount(), 2, '.', '');
         $allItems      = $quote->getAllItems();
         self::assertNotEmpty($allItems, 'Quote must have at least one item');
         $firstItem     = $allItems[0];
-        $itemRowTotal  = number_format((float) $firstItem->getRowTotal() / max(1, (float) $firstItem->getQty()), 2, '.', '');
-        $itemTotalVal  = number_format((float) $firstItem->getRowTotal(), 2, '.', '');
+        $itemRowTotal = number_format(
+            (float) $firstItem->getBaseRowTotal() / max(1, (float) $firstItem->getQty()),
+            2,
+            '.',
+            ''
+        );
+        $itemTotalVal  = number_format((float) $firstItem->getBaseRowTotal(), 2, '.', '');
         $discountValue = number_format(
-            (float) ($quote->getSubtotal() - $quote->getSubtotalWithDiscount()),
+            abs((float) ($quote->getShippingAddress()->getBaseDiscountAmount() ?? 0.0)),
             2,
             '.',
             ''
@@ -364,10 +393,18 @@ class QuoteConverterTest extends TestCase
         self::assertEqualsCanonicalizing($expected['order_data']['customer'], $od['customer'], 'customer');
 
         self::assertArrayHasKey('shipping_address', $od);
-        self::assertEqualsCanonicalizing($expected['order_data']['shipping_address'], $od['shipping_address'], 'shipping_address');
+        self::assertEqualsCanonicalizing(
+            $expected['order_data']['shipping_address'],
+            $od['shipping_address'],
+            'shipping_address'
+        );
 
         self::assertArrayHasKey('selected_shipping_option', $od);
-        self::assertEqualsCanonicalizing($expected['order_data']['selected_shipping_option'], $od['selected_shipping_option'], 'selected_shipping_option');
+        self::assertEqualsCanonicalizing(
+            $expected['order_data']['selected_shipping_option'],
+            $od['selected_shipping_option'],
+            'selected_shipping_option'
+        );
 
         self::assertArrayHasKey('shipping_options', $od);
         self::assertIsArray($od['shipping_options']);
@@ -375,7 +412,11 @@ class QuoteConverterTest extends TestCase
         $found = false;
         foreach ($od['shipping_options'] as $opt) {
             if (isset($opt['id']) && $opt['id'] === 'flatrate_flatrate') {
-                self::assertEqualsCanonicalizing($expected['order_data']['shipping_options'][0], $opt, 'flatrate shipping option');
+                self::assertEqualsCanonicalizing(
+                    $expected['order_data']['shipping_options'][0],
+                    $opt,
+                    'flatrate shipping option'
+                );
                 $found = true;
                 break;
             }
@@ -398,8 +439,68 @@ class QuoteConverterTest extends TestCase
 
         self::assertArrayHasKey('discount', $od);
         self::assertEqualsCanonicalizing($expected['order_data']['discount'], $od['discount'], 'discount');
+        $this->assertOrderDataUsesBaseCurrency($od);
+    }
 
-        self::assertSame('EUR', $currencyCode, 'Quote should be in EUR (non-base currency)');
+    /**
+     * @dataProvider nonBaseDisplayCurrencyProvider
+     * @magentoDataFixture Magento/ConfigurableProduct/_files/tax_rule.php
+     * @magentoDataFixture Magento/SalesRule/_files/cart_rule_with_coupon_5_off_no_condition.php
+     * @magentoDataFixture Magento/Checkout/_files/quote_with_virtual_product_saved.php
+     * @magentoDbIsolation enabled
+     */
+    public function testConvertFullQuoteConvertsVirtualQuoteWithNonBaseCurrency(string $displayCurrency): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        $searchCriteria = $objectManager->create(SearchCriteriaBuilder::class)
+            ->addFilter('reserved_order_id', 'test_order_with_virtual_product_without_address')
+            ->create();
+        /** @var CartRepositoryInterface $cartRepository */
+        $cartRepository = $objectManager->create(CartRepositoryInterface::class);
+        $quotes = $cartRepository->getList($searchCriteria)->getItems();
+        /** @var Quote $quote */
+        $quote = reset($quotes) ?: $objectManager->create(Quote::class);
+
+        /** @var Item[] $quoteItems */
+        $quoteItems = $quote->getAllItems();
+        /** @var Registry $registry */
+        $registry = $objectManager->get(Registry::class);
+        /** @var Rule $taxRule */
+        $taxRule = $registry->registry('_fixture/Magento_Tax_Model_Calculation_Rule');
+        $quoteConverter = $objectManager->create(QuoteConverter::class);
+
+        array_walk(
+            $quoteItems,
+            static function (Item $item) use ($taxRule): void {
+                $item->getProduct()
+                    ->setTaxClassId($taxRule->getProductTaxClassIds()[0])
+                    ->save();
+            }
+        );
+
+        $quote->setCouponCode('CART_FIXED_DISCOUNT_5');
+        $quote->getBillingAddress()
+            ->setFirstname('John')
+            ->setLastname('Smith')
+            ->setEmail('customer@example.com');
+
+        $cartRepository->save($quote);
+        $quote = $cartRepository->get((int) $quote->getId());
+        $this->applyDisplayCurrencyToQuote($quote, $displayCurrency);
+        $this->assertQuoteUsesNonBaseCurrency($quote, $displayCurrency);
+
+        $result = $quoteConverter->convertFullQuote(
+            $quote,
+            'a31a8fd6-a9e2-4c68-a834-54567bfeb4b7'
+        );
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('order_data', $result);
+        $this->assertOrderDataUsesBaseCurrency($result['order_data']);
+        self::assertSame(
+            number_format((float) $quote->getBaseGrandTotal(), 2, '.', ''),
+            $result['order_data']['amount']['value']
+        );
     }
 
     public function testDoesNotConvertShippingInformationIfAddressIsNotSet(): void
@@ -480,7 +581,11 @@ class QuoteConverterTest extends TestCase
         $quoteConverter = $objectManager->create(QuoteConverter::class, ['config' => $config]);
 
         $result = $quoteConverter->convertCustomer($quote);
-        self::assertArrayHasKey('order_data', $result, 'convertCustomer must return order_data when billing address is set');
+        self::assertArrayHasKey(
+            'order_data',
+            $result,
+            'convertCustomer must return order_data when billing address is set'
+        );
         self::assertSame('noname', $result['order_data']['customer']['first_name']);
         self::assertSame('nolastname', $result['order_data']['customer']['last_name']);
     }

--- a/Test/Integration/_Support/IntegrationTestCase.php
+++ b/Test/Integration/_Support/IntegrationTestCase.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\CheckoutPaymentBooster\Test\Integration\_Support;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Base integration test with multi-currency store configuration (USD base, EUR display).
+ *
+ * @magentoConfigFixture current_store currency/options/base USD
+ * @magentoConfigFixture current_store currency/options/default USD
+ * @magentoConfigFixture current_store currency/options/allow USD,EUR
+ * @magentoDataFixture Bold_CheckoutPaymentBooster::Test/Integration/_files/multi_currency_store.php
+ */
+abstract class IntegrationTestCase extends TestCase
+{
+    protected const BASE_CURRENCY = NonBaseCurrencyTestConfig::BASE_CURRENCY;
+
+    /**
+     * @var list<string>
+     */
+    protected const NON_BASE_DISPLAY_CURRENCIES = NonBaseCurrencyTestConfig::NON_BASE_DISPLAY_CURRENCIES;
+}

--- a/Test/Integration/_Support/NonBaseCurrencyQuoteTrait.php
+++ b/Test/Integration/_Support/NonBaseCurrencyQuoteTrait.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\CheckoutPaymentBooster\Test\Integration\_Support;
+
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\App\Http\Context as HttpContext;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Api\Data\CartInterface;
+use Magento\Quote\Model\Quote;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+
+use function reset;
+
+trait NonBaseCurrencyQuoteTrait
+{
+    /**
+     * @return array<string, array{string}>
+     */
+    public function nonBaseDisplayCurrencyProvider(): array
+    {
+        $cases = [];
+
+        foreach (NonBaseCurrencyTestConfig::NON_BASE_DISPLAY_CURRENCIES as $displayCurrency) {
+            $cases[$displayCurrency] = [$displayCurrency];
+        }
+
+        return $cases;
+    }
+
+    protected function applyDisplayCurrencyToQuote(
+        Quote $quote,
+        string $displayCurrency,
+        string $baseCurrency = NonBaseCurrencyTestConfig::BASE_CURRENCY
+    ): Quote {
+        $this->setStoreDisplayCurrency($displayCurrency, (int) $quote->getStoreId());
+
+        $store = $quote->getStore();
+        $store->unsetData('current_currency');
+        $store->setCurrentCurrencyCode($displayCurrency);
+        $quote->setBaseCurrencyCode($baseCurrency);
+        $quote->setQuoteCurrencyCode($displayCurrency);
+        $quote->setStoreCurrencyCode($displayCurrency);
+        $quote->setTotalsCollectedFlag(false);
+
+        if (!$quote->getIsVirtual()) {
+            $quote->getShippingAddress()->setCollectShippingRates(true);
+        }
+
+        $quote->collectTotals();
+
+        return $quote;
+    }
+
+    protected function loadQuoteByReservedOrderId(string $reservedOrderId): Quote
+    {
+        $this->resetQuoteRepositoryCache();
+
+        $objectManager = Bootstrap::getObjectManager();
+        $searchCriteria = $objectManager->create(SearchCriteriaBuilder::class)
+            ->addFilter('reserved_order_id', $reservedOrderId)
+            ->create();
+        $quotes = $objectManager->get(CartRepositoryInterface::class)
+            ->getList($searchCriteria)
+            ->getItems();
+
+        self::assertNotEmpty($quotes, 'Fixture quote with reserved_order_id "' . $reservedOrderId . '" not found');
+
+        return $objectManager->get(CartRepositoryInterface::class)->get((int) reset($quotes)->getId());
+    }
+
+    protected function hydrateQuoteProducts(Quote $quote): Quote
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        $productRepository = $objectManager->get(ProductRepositoryInterface::class);
+
+        foreach ($quote->getAllItems() as $item) {
+            if (!$item->getProduct()) {
+                $item->setProduct($productRepository->getById((int) $item->getProductId()));
+            }
+        }
+
+        return $quote;
+    }
+
+    protected function prepareQuoteWithDisplayCurrency(
+        string $reservedOrderId,
+        string $displayCurrency,
+        bool $persist = false
+    ): Quote {
+        $this->resetQuoteRepositoryCache();
+        $quote = $this->hydrateQuoteProducts($this->loadQuoteByReservedOrderId($reservedOrderId));
+        $quote = $this->applyDisplayCurrencyToQuote($quote, $displayCurrency);
+
+        return $persist ? $this->persistQuote($quote) : $quote;
+    }
+
+    protected function persistQuote(Quote $quote): Quote
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        $cartRepository = $objectManager->get(CartRepositoryInterface::class);
+        $quoteId = (int) $quote->getId();
+        $cartRepository->save($quote);
+        $this->resetQuoteRepositoryCache();
+
+        return $cartRepository->get($quoteId);
+    }
+
+    protected function setStoreDisplayCurrency(string $displayCurrency, ?int $storeId = null): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        $storeManager = $objectManager->get(StoreManagerInterface::class);
+        $store = $storeId === null ? $storeManager->getStore() : $storeManager->getStore($storeId);
+        $httpContext = $objectManager->get(HttpContext::class);
+
+        $httpContext->unsValue(HttpContext::CONTEXT_CURRENCY);
+        $store->unsetData('available_currency_codes');
+        $store->unsetData('current_currency');
+        $store->setCurrentCurrencyCode($displayCurrency);
+    }
+
+    protected function resetQuoteRepositoryCache(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        $cartRepository = $objectManager->get(CartRepositoryInterface::class);
+
+        if (method_exists($cartRepository, '_resetState')) {
+            $cartRepository->_resetState();
+        }
+    }
+
+    private function assertQuoteUsesNonBaseCurrency(
+        CartInterface $quote,
+        string $displayCurrency,
+        string $baseCurrency = NonBaseCurrencyTestConfig::BASE_CURRENCY
+    ): void {
+        self::assertSame($displayCurrency, $quote->getQuoteCurrencyCode());
+        self::assertSame($baseCurrency, $quote->getBaseCurrencyCode());
+        self::assertNotSame($quote->getQuoteCurrencyCode(), $quote->getBaseCurrencyCode());
+    }
+
+    private function assertDisplayAndBaseGrandTotalsDiffer(CartInterface $quote): void
+    {
+        self::assertNotEquals(
+            (float) $quote->getGrandTotal(),
+            (float) $quote->getBaseGrandTotal(),
+            'Display and base grand totals must differ for non-base currency quotes'
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $orderData
+     */
+    private function assertOrderDataUsesBaseCurrency(
+        array $orderData,
+        string $baseCurrency = NonBaseCurrencyTestConfig::BASE_CURRENCY
+    ): void {
+        self::assertSame($baseCurrency, $orderData['amount']['currency_code'] ?? null);
+        self::assertSame($baseCurrency, $orderData['item_total']['currency_code'] ?? null);
+        self::assertSame($baseCurrency, $orderData['tax_total']['currency_code'] ?? null);
+        self::assertSame($baseCurrency, $orderData['discount']['currency_code'] ?? null);
+
+        if (isset($orderData['selected_shipping_option']['amount']['currency_code'])) {
+            self::assertSame(
+                $baseCurrency,
+                $orderData['selected_shipping_option']['amount']['currency_code']
+            );
+        }
+    }
+}

--- a/Test/Integration/_Support/NonBaseCurrencyTestConfig.php
+++ b/Test/Integration/_Support/NonBaseCurrencyTestConfig.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\CheckoutPaymentBooster\Test\Integration\_Support;
+
+/**
+ * Shared currency constants for multi-currency integration tests.
+ */
+class NonBaseCurrencyTestConfig
+{
+    public const BASE_CURRENCY = 'USD';
+
+    /**
+     * @var list<string>
+     */
+    public const NON_BASE_DISPLAY_CURRENCIES = ['EUR'];
+}

--- a/Test/Integration/_files/magento_quote_bold_order_non_base_currency.php
+++ b/Test/Integration/_files/magento_quote_bold_order_non_base_currency.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Bold\CheckoutPaymentBooster\Api\MagentoQuoteBoldOrderRepositoryInterface;
+use Bold\CheckoutPaymentBooster\Model\MagentoQuoteBoldOrder;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\ResourceModel\Quote as QuoteResourceModel;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\TestFramework\Workaround\Override\Fixture\Resolver;
+
+Resolver::getInstance()->requireDataFixture(
+    'Bold_CheckoutPaymentBooster::Test/Integration/_files/quote_items_non_base_currency.php'
+);
+
+$objectManager = Bootstrap::getObjectManager();
+/** @var QuoteResourceModel $quoteResourceModel */
+$quoteResourceModel = $objectManager->create(QuoteResourceModel::class);
+/** @var Quote $quote */
+$quote = $objectManager->create(Quote::class);
+/** @var MagentoQuoteBoldOrder $magentoQuoteBoldOrder */
+$magentoQuoteBoldOrder = $objectManager->create(MagentoQuoteBoldOrder::class);
+/** @var MagentoQuoteBoldOrderRepositoryInterface $magentoQuoteBoldOrderRepository */
+$magentoQuoteBoldOrderRepository = $objectManager->create(MagentoQuoteBoldOrderRepositoryInterface::class);
+
+$quoteResourceModel->load($quote, 'test_order_item_with_items', 'reserved_order_id');
+
+$magentoQuoteBoldOrder
+    ->setBoldOrderId('e5537d5a79264a53995b9ccf6b86225b46925006f6e24a59a8892fbb524b1aa0')
+    ->setQuoteId($quote->getId());
+
+$magentoQuoteBoldOrderRepository->save($magentoQuoteBoldOrder);

--- a/Test/Integration/_files/multi_currency_store.php
+++ b/Test/Integration/_files/multi_currency_store.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use Magento\Config\App\Config\Type\System as Config;
+use Magento\Config\Model\ResourceModel\Config as ConfigResource;
+use Magento\Directory\Model\Currency;
+use Magento\Directory\Model\ResourceModel\Currency as CurrencyResource;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Store\Model\Store;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+
+$objectManager = Bootstrap::getObjectManager();
+
+/** @var Store $store */
+$store = $objectManager->create(Store::class);
+$store->load('default', 'code');
+$storeId = (int) $store->getId();
+
+/** @var ConfigResource $configResource */
+$configResource = $objectManager->get(ConfigResource::class);
+$configResource->saveConfig(Currency::XML_PATH_CURRENCY_BASE, 'USD', ScopeInterface::SCOPE_STORES, $storeId);
+$configResource->saveConfig(Currency::XML_PATH_CURRENCY_DEFAULT, 'USD', ScopeInterface::SCOPE_STORES, $storeId);
+$configResource->saveConfig(
+    Currency::XML_PATH_CURRENCY_ALLOW,
+    'USD,EUR',
+    ScopeInterface::SCOPE_STORES,
+    $storeId
+);
+
+/** Configuration cache clean is required to reload currency settings. */
+/** @var Config $config */
+$config = $objectManager->get(Config::class);
+$config->clean();
+
+$store->unsetData('available_currency_codes');
+$store->unsetData('current_currency');
+
+/** @var StoreManagerInterface $storeManager */
+$storeManager = $objectManager->get(StoreManagerInterface::class);
+$storeManager->getStore($storeId)->unsetData('available_currency_codes');
+$storeManager->getStore($storeId)->unsetData('current_currency');
+
+/** @var CurrencyResource $currencyResource */
+$currencyResource = $objectManager->create(CurrencyResource::class);
+$currencyResource->saveRates(
+    [
+        'USD' => [
+            'USD' => 1.0,
+            'EUR' => 0.92,
+        ],
+        'EUR' => [
+            'EUR' => 1.0,
+            'USD' => 1.08695652,
+        ],
+    ]
+);

--- a/Test/Integration/_files/quote_items_non_base_currency.php
+++ b/Test/Integration/_files/quote_items_non_base_currency.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 use Magento\Quote\Model\QuoteFactory;
 use Magento\Quote\Model\ResourceModel\Quote as QuoteResource;
 use Magento\TestFramework\Helper\Bootstrap;
+use Magento\TestFramework\Workaround\Override\Fixture\Resolver;
 
-require __DIR__ . '/quote_with_shipping_tax_and_discount.php';
+Resolver::getInstance()->requireDataFixture('Magento/Checkout/_files/quote_with_items_saved.php');
 
 $objectManager = Bootstrap::getObjectManager();
 /** @var QuoteFactory $quoteFactory */
@@ -15,18 +16,16 @@ $quoteFactory = $objectManager->get(QuoteFactory::class);
 $quoteResource = $objectManager->get(QuoteResource::class);
 $quote = $quoteFactory->create();
 
-$quoteResource->load($quote, 'test_order_1', 'reserved_order_id');
+$quoteResource->load($quote, 'test_order_item_with_items', 'reserved_order_id');
 if (!$quote->getId()) {
-    throw new \RuntimeException('Quote with reserved_order_id test_order_1 not found.');
+    throw new \RuntimeException('Quote with reserved_order_id test_order_item_with_items not found.');
 }
 
-// Default fixture currency is EUR; integration tests re-apply display currency per data-provider row.
 $store = $quote->getStore();
 $store->unsetData('current_currency');
 $store->setCurrentCurrencyCode('EUR');
 $quote->setBaseCurrencyCode('USD');
 $quote->setQuoteCurrencyCode('EUR');
 $quote->setStoreCurrencyCode('EUR');
-$quote->getShippingAddress()->setCollectShippingRates(true);
 $quote->collectTotals();
 $quote->save();

--- a/UI/PaymentBoosterConfigProvider.php
+++ b/UI/PaymentBoosterConfigProvider.php
@@ -147,7 +147,12 @@ class PaymentBoosterConfigProvider implements ConfigProviderInterface
         $epsAuthToken = $this->checkoutData->getEpsAuthToken();
         $paymentGateways = $this->checkoutData->getPaymentGateways();
         $shouldVault = $this->checkoutData->getShouldVault();
-        $currency = $store->getCurrentCurrency()->getCode();
+        $currency = $fromQuote
+            ? (string)$quote->getBaseCurrencyCode()
+            : (string)$store->getBaseCurrencyCode();
+        $displayCurrency = $fromQuote
+            ? (string)$quote->getQuoteCurrencyCode()
+            : (string)$store->getCurrentCurrency()->getCode();
         $shopUrl = $store->getBaseUrl();
         if ($jwtToken === null || $epsAuthToken === null || $paymentGateways === []) {
             $errorMsgs = [];
@@ -202,6 +207,7 @@ class PaymentBoosterConfigProvider implements ConfigProviderInterface
                     ],
                 ],
                 'currency' => $currency,
+                'display_currency_code' => $displayCurrency,
             ],
         ];
     }

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": [
         "MIT"
     ],
-    "version": "2.7.3",
+    "version": "2.7.4",
     "require": {
         "php": ">=7.2 <8.6",
         "ext-curl": "*",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": [
         "MIT"
     ],
-    "version": "2.7.3",
+    "version": "2.7.5",
     "require": {
         "php": ">=7.2 <8.6",
         "ext-curl": "*",

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -33,6 +33,11 @@
             <argument name="logger" xsi:type="object">Bold\CheckoutPaymentBooster\Model\Http\Client\RequestsLogger\Logger</argument>
         </arguments>
     </type>
+    <type name="Bold\CheckoutPaymentBooster\Model\Log\OrderTracker">
+        <arguments>
+            <argument name="logger" xsi:type="object">Bold\CheckoutPaymentBooster\Model\Http\Client\RequestsLogger\Logger</argument>
+        </arguments>
+    </type>
     <virtualType name="Bold\CheckoutPaymentBooster\Model\Http\Client\RequestsLogger\Logger" type="Magento\Framework\Logger\Monolog">
         <arguments>
             <argument name="handlers" xsi:type="array">

--- a/view/frontend/web/js/action/express-pay/get-required-order-data-action.js
+++ b/view/frontend/web/js/action/express-pay/get-required-order-data-action.js
@@ -97,16 +97,16 @@ define(
             const totals = quote.getTotals();
 
             const order_balance = window.checkoutConfig.bold.addTaxAmountFrontendBalance
-                ? (parseFloat((totals()['grand_total'] || 0)) + parseFloat((totals()['tax_amount'] || 0))) * 100
-                : parseFloat((totals()['grand_total'] || 0)) * 100;
+                ? (parseFloat((totals()['base_grand_total'] || 0)) + parseFloat((totals()['base_tax_amount'] || 0))) * 100
+                : parseFloat((totals()['base_grand_total'] || 0)) * 100;
 
             return {
-                order_total: parseFloat(totals()['grand_total'] || 0) * 100,
+                order_total: parseFloat(totals()['base_grand_total'] || 0) * 100,
                 order_balance,
-                shipping_total: parseFloat(totals()['shipping_amount'] || 0) * 100,
-                discounts_total: parseFloat(totals()['discount_amount'] || 0) * 100,
+                shipping_total: parseFloat(totals()['base_shipping_amount'] || 0) * 100,
+                discounts_total: parseFloat(totals()['base_discount_amount'] || 0) * 100,
                 fees_total: parseFloat(totals()['fee_amount'] || 0) * 100,
-                taxes_total: parseFloat(totals()['tax_amount'] || 0) * 100,
+                taxes_total: parseFloat(totals()['base_tax_amount'] || 0) * 100,
             };
         }
 
@@ -160,7 +160,7 @@ define(
                     case 'shipping_options':
                         payload[requirement] = shippingService.getShippingRates().map(option => ({
                             label: `${option.carrier_title} - ${option.method_title}`,
-                            amount: parseFloat(option.amount) * 100,
+                            amount: parseFloat(option.base_amount ?? option.amount) * 100,
                             id: `${option.carrier_code}_${option.method_code}`,
                             is_selected: option.carrier_code === quote.shippingMethod()?.carrier_code &&
                                 option.method_code === quote.shippingMethod()?.method_code


### PR DESCRIPTION
Summary
Release v2.7.4 bundles three production fixes for PPCP digital-wallet checkout:

CHK-9605 — Stop reusing a completed Bold public_order_id when Magento preserves the same digital-wallet quote across consecutive orders.
Public order ID binding — Keep session, quote extension, and DB bold_order_id aligned through hydrate/auth so payments bind to the active checkout session.
CHK-9608 — Send base currency amounts to Bold/PayPal while Magento continues to place orders in the customer’s display currency (fixes incorrect_currency and AUTH_CAPTURE_CURRENCY_MISMATCH on EUR storefronts with USD base).