### PR TITLE
Remove deprecated curl_close() call for PHP 8.5 compatibility

### DIFF
--- a/Model/Http/Client/Command/Client/Curl.php
+++ b/Model/Http/Client/Command/Client/Curl.php
@@ -103,7 +103,6 @@ class Curl extends CurlCore
         }
 
         $this->_responseStatus = $httpCode;
-        curl_close($this->_ch);
         // phpcs:enable Magento2.Functions.DiscouragedFunction.Discouraged
     }
 }


### PR DESCRIPTION
curl_close() has been a no-op since PHP 8.0 (curl handles are objects freed by GC) and emits a deprecation notice as of PHP 8.5, which Magento's error handler converts to an exception in developer mode, breaking config saves and all PUT/PATCH/DELETE Bold API calls.